### PR TITLE
AE-2038: Set the keys for aineistot to correspond to the API paths

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
@@ -97,7 +97,7 @@
 (defn update-aineisto-in-s3! [db whoami aws-s3-client aineisto-id]
   (log/info (str "Starting updating of aineisto (id: " aineisto-id ")."))
   (let [csv-reducible-query (aineisto-reducible-query db whoami aineisto-id)
-        key (str "/aineistot/" aineisto-id "/energiatodistukset.csv")
+        key (str "/api/signed/aineistot/" aineisto-id "/energiatodistukset.csv")
         ;; This part is used to store rows until it reaches 5MB which
         ;; is the minimum requirement by `upload-part-fn`.
         current-part (ByteBuffer/allocate (* 8 1024 1024))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
@@ -99,15 +99,15 @@
 
 (t/deftest update-aineistot-test
   (t/testing "Aineistot don't exist before generating"
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/aineistot/1/energiatodistukset.csv")))
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/aineistot/2/energiatodistukset.csv")))
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/aineistot/3/energiatodistukset.csv"))))
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/1/energiatodistukset.csv")))
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/2/energiatodistukset.csv")))
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/3/energiatodistukset.csv"))))
 
   (t/testing "Aineistot exist after generating"
     (aineisto/update-aineistot-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client*)
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/aineistot/1/energiatodistukset.csv")))
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/aineistot/2/energiatodistukset.csv")))
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/aineistot/3/energiatodistukset.csv"))))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/1/energiatodistukset.csv")))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/2/energiatodistukset.csv")))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/3/energiatodistukset.csv"))))
 
   (t/testing "New energiatodistus shows up correctly when updating aineistot"
     (let [;; Add laatija
@@ -139,18 +139,18 @@
       (aineisto/update-aineistot-in-s3! ts/*db* whoami ts/*aws-s3-client*)
 
       ;; Aineisto 1 - Test that rakennustunnus-1 exists, but that there is only one row of energiatodistukset.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/aineistot/1/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/1/energiatodistukset.csv")]
         (t/is (true? (str/includes? first rakennustunnus-1)))
         (t/is (nil? second)))
 
       ;; Aineisto 2 - Test that rakennustunnus-1 exists, but that there is only one row of energiatodistukset.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/aineistot/2/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/2/energiatodistukset.csv")]
         (t/is (true? (str/includes? first rakennustunnus-1)))
         (t/is (nil? second)))
 
       ;; Aineisto 3 - Test that one row exists and that the rakennustunnus can't be found as this set should be
       ;; anonymized.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/aineistot/3/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/3/energiatodistukset.csv")]
         (t/is (false? (str/includes? first rakennustunnus-1)))
         (t/is (false? (nil? first)))
         (t/is (nil? second)))
@@ -163,19 +163,19 @@
 
       ;; Aineisto 1 - Test that both rakennustunnus exist. It does not matter which one is which
       ;; as the order of them is not guaranteed.
-      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto "/aineistot/1/energiatodistukset.csv")]
+      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/1/energiatodistukset.csv")]
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-1 csv-et-lines)))
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-2 csv-et-lines))))
 
       ;; Aineisto 2 - Test that both rakennustunnus exist. It does not matter which one is which
       ;; as the order of them is not guaranteed.
-      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto "/aineistot/2/energiatodistukset.csv")]
+      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/2/energiatodistukset.csv")]
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-1 csv-et-lines)))
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-2 csv-et-lines))))
 
       ;; Aineisto 3 - Test that two rows exists and that either of the rakennustunnukset can't be found
       ;; as this set is be anonymized.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/aineistot/3/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/3/energiatodistukset.csv")]
         ;; Rakennustunnus-1 can't be found
         (t/is (false? (str/includes? first rakennustunnus-1)))
         (t/is (false? (str/includes? second rakennustunnus-1)))


### PR DESCRIPTION
An alternative to this would be to create a CloudFront function to remove the /api/signed part but it seems that it would introduce unnecessary complexities