### PR TITLE
AE-1923: Mark older käytönvalvonta toimenpidetypes that should have comments as allowing comments in db

### DIFF
--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/valvonta_kaytto_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/valvonta_kaytto_test.clj
@@ -18,7 +18,7 @@
                  :label-sv             "Valvonnan aloitus (sv)"
                  :valid                true
                  :manually-deliverable false
-                 :allow-comments       false}
+                 :allow-comments       true}
                 {:id                   1
                  :label-fi             "Tietopyyntö 2021"
                  :label-sv             "Begäran om uppgifter 2021"
@@ -42,13 +42,13 @@
                  :label-sv             "Käskypäätös (sv)"
                  :valid                true
                  :manually-deliverable false
-                 :allow-comments       false}
+                 :allow-comments       true}
                 {:id                   5
                  :label-fi             "Valvonnan lopetus"
                  :label-sv             "Valvonnan lopetus (sv)"
                  :valid                true
                  :manually-deliverable false
-                 :allow-comments       false}
+                 :allow-comments       true}
                 {:id                   6
                  :label-fi             "HaO-käsittely"
                  :label-sv             "HaO-käsittely (sv)"

--- a/etp-core/etp-db/src/main/sql/migration/repeatable/vk_template/r-0-vk-toimenpidetype.sql
+++ b/etp-core/etp-db/src/main/sql/migration/repeatable/vk_template/r-0-vk-toimenpidetype.sql
@@ -1,11 +1,11 @@
 insert into vk_toimenpidetype (id, label_fi, label_sv, ordinal, valid, manually_deliverable, allow_comments)
 values
-(0, 'Valvonnan aloitus', 'Valvonnan aloitus (sv)', 1, true, false, false),
+(0, 'Valvonnan aloitus', 'Valvonnan aloitus (sv)', 1, true, false, true),
 (1, 'Tietopyyntö 2021', 'Begäran om uppgifter 2021', 2, false, false, false),
 (2, 'Kehotus', ' Uppmaning', 3, true, false, false),
 (3, 'Varoitus', 'Varning', 4, true, false, false),
-(4, 'Käskypäätös', 'Käskypäätös (sv)', 5, true, false, false),
-(5, 'Valvonnan lopetus', 'Valvonnan lopetus (sv)', 6, true, false, false),
+(4, 'Käskypäätös', 'Käskypäätös (sv)', 5, true, false, true),
+(5, 'Valvonnan lopetus', 'Valvonnan lopetus (sv)', 6, true, false, true),
 (6, 'HaO-käsittely', 'HaO-käsittely (sv)', 7, true, false, true),
 (7, 'Käskypäätös / kuulemiskirje', 'Käskypäätös / kuulemiskirje (sv)', 8, true, true, true),
 (8, 'Käskypäätös / varsinainen päätös', 'Käskypäätös / varsinainen päätös (sv)', 9, true, true, true),

--- a/etp-front/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
+++ b/etp-front/src/pages/valvonta-kaytto/new-toimenpide-dialog.svelte
@@ -211,7 +211,7 @@
     </div>
   {/if}
 
-  {#if commentingAllowed || R.isEmpty(templates)}
+  {#if commentingAllowed}
     <div class="w-full py-4">
       <Textarea
         id={'toimenpide.description'}


### PR DESCRIPTION
AE-1923: 

Mark older käytönvalvonta toimenpidetypes that should have comments as allowing comments in db

- Previously there has been a logic in frontend to allow comments when there are no document templates attached to the toimenpidetype
- Now we change the the older toimenpidetypes to use the flag allow_comments that is saved to database
- Toimenpidetypes changed now are "Valvonnan aloitus", "Käskypäätös" and "Valvonnan lopetus"

Remove condition in käytönvalvonta new-toimenpide-dialog to show commenting when there are no document template

- Commenting is now only allowed for toimenpidetypes that have it configured to be allowed in vk_toimenpidetype db table