### PR TITLE
AE-1968: Add missing valvonta lines to exported CSV

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
@@ -389,9 +389,9 @@
          toimenpide.id, toimenpidetype.label_fi, toimenpide.publish_time,
          fullname(kayttaja)
        from vk_valvonta valvonta
-         inner join postinumero on postinumero.id = valvonta.postinumero
-         inner join vk_toimenpide toimenpide on toimenpide.valvonta_id = valvonta.id
-         inner join vk_toimenpidetype toimenpidetype on toimenpidetype.id = toimenpide.type_id
+         left join postinumero on postinumero.id = valvonta.postinumero
+         left join vk_toimenpide toimenpide on toimenpide.valvonta_id = valvonta.id
+         left join vk_toimenpidetype toimenpidetype on toimenpidetype.id = toimenpide.type_id
          left join kayttaja on kayttaja.id = valvonta.valvoja_id
        where not deleted"
       {:row-fn        (comp write! csv-service/csv-line)


### PR DESCRIPTION
Generating the valvonta.csv used inner join instead of left join and thus dropped some lines, which after discussion with the customer were added to the csv. No lines missing because of recent changes were found.
