### PR TITLE
AE-2014: Check if Käsittely toimenpide is already ready to determine if uudelleenkäsittele asia transition needs to be used in käytönvalvonta

### DIFF
--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/asha_test.clj
@@ -324,5 +324,5 @@
                                                           :response-status  200
                                                           :request-received move-called}})]
             (asha-service/move-processing-action! sender-id request-id case-number {"Tiedoksianto ja toimeenpano" "UNFINISHED"
-                                                                                    "Käsittely" "FINISHED"} "Käsittely")
+                                                                                    "Käsittely" "READY"} "Käsittely")
             (t/is (= 1 @move-called))))))))


### PR DESCRIPTION
AE-2014: Check if Käsittely toimenpide is already ready to determine if uudelleenkäsittele asia transition needs to be used in käytönvalvonta

- Previously it was checked that we were moving from an unfinished tiedoksianto ja toimeenpano toimenpide but this wasn't right as the state of that toimenpide is not necessarily unfinished