### PR TITLE
AE-2105: Use all osapuolet in käytönvalvonta for kehotus toimenpide, others use only owners

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/toimenpide.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/toimenpide.clj
@@ -44,6 +44,7 @@
 (def case-open? (partial type? :case))
 (def case-close? (partial type? :closed))
 (def send-tiedoksi? (partial type? :rfi-request))
+(def kehotus? (partial type? :rfi-order))
 
 (def kaskypaatos-kuulemiskirje? (partial type? :decision-order-hearing-letter))
 


### PR DESCRIPTION
AE-2105: Use all osapuolet in käytönvalvonta for kehotus toimenpide, others use only owners

- Fixes kiinteistönvälittäjät appearing in asha in toimenpidetypes where they are not needed