### PR TITLE
Fix docker build failing on fresh clone.

### DIFF
--- a/etp-core/etp-backend/.dockerignore
+++ b/etp-core/etp-backend/.dockerignore
@@ -1,0 +1,5 @@
+target
+.nrepl-port
+etp-backend.iml
+.cpcache
+.clj-kondo/.cache

--- a/etp-core/etp-backend/Dockerfile
+++ b/etp-core/etp-backend/Dockerfile
@@ -1,8 +1,8 @@
 # Build image
 FROM --platform=amd64 clojure:temurin-17-tools-deps-1.11.1.1347-alpine as builder
 
-COPY . /usr/src/app
-WORKDIR /usr/src/app
+COPY . /usr/src/etp-backend
+WORKDIR /usr/src/etp-backend
 RUN clojure -M:uberjar
 
 
@@ -20,7 +20,7 @@ ln -s /usr/local/bin/libreoffice7.1 /usr/local/bin/libreoffice
 
 # The application
 COPY libreoffice/ /opt/etp/libreoffice/
-COPY --from=builder /usr/src/app/target/etp-backend.jar /opt/etp/target/
+COPY --from=builder /usr/src/etp-backend/target/etp-backend.jar /opt/etp/target/
 COPY start.sh /opt/etp/
 
 WORKDIR /opt/etp


### PR DESCRIPTION
Uberjar file name comes from folder in which was built. Because of this, the jar used in docker build was one built on host and not in the builder. This went unnoticed because CI always builds the uberjar before the docker image, but would fail on fresh clone otherwise.

Fixed by changing directory name in builder image to match repository naming.

Also added .dockerignore to improve build caching, speed up builds and prevent such errors in the future.