### PR TITLE
Remove jetty replacement

### DIFF
--- a/etp-core/etp-backend/deps.edn
+++ b/etp-core/etp-backend/deps.edn
@@ -47,9 +47,7 @@
                                                                       ring/ring-jetty-adapter
                                                                       org.clojure/data.json]}
              org.clojure/core.match                    {:mvn/version "1.1.0"}
-             com.cognitect.aws/api                     {:mvn/version "0.8.692"
-                                                        :exclusions  [org.eclipse.jetty/jetty-client]} ; Replaced by a newer version
-             org.eclipse.jetty/jetty-client            {:mvn/version "9.4.53.v20231009"} ; aws-api uses vulnerable jetty version. Bring in a bit newer one
+             com.cognitect.aws/api                     {:mvn/version "0.8.692"}
              com.cognitect.aws/endpoints               {:mvn/version "1.1.12.626"}
              com.cognitect.aws/s3                      {:mvn/version "848.2.1413.0"}
              de.ubercode.clostache/clostache           {:mvn/version "1.4.0"}


### PR DESCRIPTION
com.cognitect.aws/api is using the fixed jetty version. No need to override anymore.