### PR TITLE
Fix flakyness in e2e test setup

### DIFF
--- a/e2e-tests/cypress/docker-compose.yml
+++ b/e2e-tests/cypress/docker-compose.yml
@@ -64,4 +64,4 @@ services:
       ./db.sh migrate dev
     depends_on:
       db:
-        condition: service_started
+        condition: service_healthy

--- a/e2e-tests/cypress/start-e2e-env.sh
+++ b/e2e-tests/cypress/start-e2e-env.sh
@@ -8,7 +8,7 @@ set -euxo pipefail
 # Start backend and wait for it and frontend to be ready
 
 docker compose up --build -d frontend
-docker compose up --build migration-runner
+docker compose up --build migration-runner --exit-code-from migration-runner
 docker compose exec db dropdb -U postgres cypress_test --if-exists --force
 docker compose exec db createdb -U postgres -T etp_dev cypress_test
 echo -e "\e[1;33m Waiting for frontend to be healthy. Can take ~20s. \e[0m"

--- a/etp-core/docker/docker-compose.yml
+++ b/etp-core/docker/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       - 127.0.0.1:5432:5432
     environment:
       POSTGRES_PASSWORD: etp
+    healthcheck:
+      test: pg_isready -U postgres
+      interval: 1s
+      timeout: 5s
+      retries: 30
 
   admin:
     image: dpage/pgadmin4


### PR DESCRIPTION
Docker compose does not care about exit codes of jobs. Migration runner failed sometimes, perhaps because DB was not ready.

Added a check for migration-runner exit code in e2e start script.

Added a healthcheck for db in compose, and require it to be healthy before migration runner is run.