### PR TITLE
AE-2063: Add energiatodistus hankittu column to käytönvalvonta csv

### DIFF
--- a/e2e-tests/cypress/.gitignore
+++ b/e2e-tests/cypress/.gitignore
@@ -18,3 +18,4 @@
 # Cypress results
 /cypress/screenshots
 /cypress/videos
+/cypress/downloads

--- a/e2e-tests/cypress/cypress/e2e/kaytonvalvonta/kaytonvalvonta.cy.js
+++ b/e2e-tests/cypress/cypress/e2e/kaytonvalvonta/kaytonvalvonta.cy.js
@@ -605,6 +605,11 @@ const reopenValvonta = () => {
   ).should('be.visible');
 };
 
+const downloadValvonnatCsv = () => {
+  cy.contains('Käytön­valvon­nat').click();
+  cy.get('[data-cy="Lataa kaikki valvonnat"]').click();
+};
+
 const navigateToKaytonvalvonta = () => {
   cy.visit('/');
   cy.contains('Käytön­valvon­nat').click();
@@ -679,6 +684,8 @@ context('Käytönvalvonta', () => {
 
     // Aloita valvonta button should not exist at this point
     cy.get('[data-cy="start-button"]').should('not.exist');
+
+    downloadValvonnatCsv();
   });
 
   it('postinumero is a required field', () => {

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus.clj
@@ -570,10 +570,13 @@
         (exception/throw-ex-info!
           :not-signed (str "Energiatodistus " id " pdf for language " language " is not signed"))))))
 
-(defn end-energiatodistus-signing! [db aws-s3-client whoami id & [{:keys [skip-pdf-signed-assert?]}]]
+(defn end-energiatodistus-signing! [db aws-s3-client whoami id & [{:keys [skip-pdf-signed-assert? allekirjoitusaika]}]]
   (jdbc/with-db-transaction [db db]
     (let [result (energiatodistus-db/update-energiatodistus-allekirjoitettu!
-                   db {:id id :laatija-id (:id whoami)})]
+                   db
+                   {:id id
+                    :laatija-id (:id whoami)
+                    :allekirjoitusaika allekirjoitusaika})]
       (if (= result 1)
         (let [energiatodistus (find-energiatodistus db id)]
           (when-not skip-pdf-signed-assert?

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
@@ -437,7 +437,7 @@
                                                coalesce(next_toimenpide.create_time, (toimenpide.deadline_date + 1)::timestamptz,
                                                                                      toimenpide.create_time)) @>
                                 energiatodistus.allekirjoitusaika
-                                LIMIT 1) energiatodistus on true
+                                limit 1) energiatodistus on true
       where not valvonta.deleted"
 
       {:row-fn        (comp write! csv-service/csv-line boolean->cross)

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
@@ -412,7 +412,10 @@
       left join lateral (select energiatodistus.id
                                 from energiatodistus
                                 where energiatodistus.pt$rakennustunnus = valvonta.rakennustunnus
-                                and tstzrange(toimenpide.create_time, coalesce(toimenpide.deadline_date::timestamptz, toimenpide.create_time)) @>
+                                -- tszrange is exclusive in the end, so adding one to deadline date and converting it to
+                                -- timestamp means it's at the beginning of the day after deadline -> timestamps on the
+                                -- deadline date are included in the range
+                                and tstzrange(toimenpide.create_time, coalesce((toimenpide.deadline_date + 1)::timestamptz, toimenpide.create_time)) @>
                                 energiatodistus.allekirjoitusaika LIMIT 1) energiatodistus on true
       where not valvonta.deleted"
 

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
@@ -382,7 +382,7 @@
      "katuosoite" "postinumero" "postitoimipaikka"
      "toimenpide-id" "toimenpidetyyppi" "aika" "valvoja" "energiatodistus hankittu"]))
 
-(defn- boolean->cross
+(defn- boolean->checked
   "Represent boolean as x when it's true in käytönvalvonta-csv and as empty when false"
   [csv-row-coll]
   (map
@@ -440,7 +440,7 @@
                                      limit 1) energiatodistus on true
            where not valvonta.deleted"
 
-      {:row-fn        (comp write! csv-service/csv-line boolean->cross)
+      {:row-fn        (comp write! csv-service/csv-line boolean->checked)
        :as-arrays?    :cols-as-is
        :result-set-fn dorun
        :result-type   :forward-only

--- a/etp-core/etp-backend/src/main/sql/solita/etp/db/energiatodistus.sql
+++ b/etp-core/etp-backend/src/main/sql/solita/etp/db/energiatodistus.sql
@@ -39,7 +39,7 @@ where tila_id = et_tilat.allekirjoituksessa and laatija_id = :laatija-id and id 
 -- name: update-energiatodistus-allekirjoitettu!
 update energiatodistus set
   tila_id = et_tilat.allekirjoitettu,
-  allekirjoitusaika = now(),
+  allekirjoitusaika = coalesce(:allekirjoitusaika, now()),
   voimassaolo_paattymisaika =
     timezone('Europe/Helsinki',
       timezone('Europe/Helsinki', now())::date::timestamp without time zone

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_history_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_history_test.clj
@@ -169,28 +169,28 @@
 
     ;; Energiatodistus 1 state history
     (t/is (= 7 (-> history-1 :state-history count)))
+    (t/is (= :allekirjoitusaika (-> history-1 :state-history first :k)))
     (t/is (= {:modifiedby-fullname laatija-1-fullname
               :k :tila-id
               :init-v nil
               :new-v 0
               :type :number
               :external-api false}
-             (-> history-1 :state-history first (dissoc :modifytime))))
+             (-> history-1 :state-history second (dissoc :modifytime))))
     (t/is (= {:modifiedby-fullname laatija-1-fullname
               :k :tila-id
               :init-v 0
               :new-v 1
               :type :number
               :external-api false}
-            (-> history-1 :state-history second (dissoc :modifytime))))
+            (-> history-1 :state-history (nth 2) (dissoc :modifytime))))
     (t/is (= {:modifiedby-fullname laatija-1-fullname
               :k :tila-id
               :init-v 0
               :new-v 2
               :type :number
               :external-api false}
-             (-> history-1 :state-history (nth 2) (dissoc :modifytime))))
-    (t/is (= :allekirjoitusaika (-> history-1 :state-history (nth 3) :k)))
+             (-> history-1 :state-history (nth 3) (dissoc :modifytime))))
     (t/is (= {:modifiedby-fullname laatija-2-fullname
               :k :tila-id
               :init-v 0
@@ -225,28 +225,28 @@
 
     ;; Energiatodistus 2 state history
     (t/is (= 5 (-> history-2 :state-history count)))
+    (t/is (= :allekirjoitusaika (-> history-2 :state-history first :k)))
     (t/is (= {:modifiedby-fullname laatija-2-fullname
               :k :tila-id
               :init-v nil
               :new-v 0
               :type :number
               :external-api false}
-             (-> history-2 :state-history first (dissoc :modifytime))))
+             (-> history-2 :state-history second (dissoc :modifytime))))
     (t/is (= {:modifiedby-fullname laatija-2-fullname
               :k :tila-id
               :init-v 0
               :new-v 1
               :type :number
               :external-api false}
-             (-> history-2 :state-history second (dissoc :modifytime))))
+             (-> history-2 :state-history (nth 2) (dissoc :modifytime))))
     (t/is (= {:modifiedby-fullname laatija-2-fullname
               :k :tila-id
               :init-v 0
               :new-v 2
               :type :number
               :external-api false}
-             (-> history-2 :state-history (nth 2) (dissoc :modifytime))))
-    (t/is (= :allekirjoitusaika (-> history-2 :state-history (nth 3) :k)))
+             (-> history-2 :state-history (nth 3) (dissoc :modifytime))))
     (t/is (= :voimassaolo-paattymisaika
              (-> history-2 :state-history last :k)))
 

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_pdf_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_pdf_test.clj
@@ -199,8 +199,8 @@
              :not-in-signing))
     (energiatodistus-test-data/sign-at-time! id
                                              laatija-id
-                                             energiatodistus-test-data/time-when-test-cert-not-expired
-                                             false)
+                                             false
+                                             energiatodistus-test-data/time-when-test-cert-not-expired)
     (t/is (= (service/sign-energiatodistus-pdf db
                                                ts/*aws-s3-client*
                                                whoami

--- a/etp-core/etp-backend/src/test/clj/solita/etp/test_data/energiatodistus.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/test_data/energiatodistus.clj
@@ -136,7 +136,8 @@
                                                           ts/*aws-s3-client*
                                                           whoami
                                                           energiatodistus-id
-                                                          {:skip-pdf-signed-assert? true})))
+                                                          {:skip-pdf-signed-assert? true
+                                                           :allekirjoitusaika now})))
 
 (def time-when-test-cert-not-expired (Instant/parse "2022-05-20T12:00:00Z"))
 (def time-when-test-cert-expired (Instant/parse "2022-05-25T12:00:00Z"))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/test_data/generators.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/test_data/generators.clj
@@ -6,7 +6,9 @@
             [solita.etp.schema.geo :as geo]
             [solita.etp.schema.laatija :as laatija]
             [solita.etp.schema.energiatodistus :as energiatodistus]
-            [solita.etp.schema.kayttaja]))
+            [solita.etp.schema.kayttaja])
+  (:import (java.time Instant LocalDate)
+           (java.util UUID)))
 
 (defn unique-henkilotunnukset-f []
   (let [state (atom 0)]
@@ -20,7 +22,7 @@
 (def unique-henkilotunnukset (unique-henkilotunnukset-f))
 
 (defn unique-emails [n]
-  (take n (repeatedly #(str (java.util.UUID/randomUUID) "@example.com"))))
+  (take n (repeatedly #(str (UUID/randomUUID) "@example.com"))))
 
 (def unique-ytunnukset
   (->> (range)
@@ -59,8 +61,8 @@
    common/Henkilotunnus                     (g/always "130200A892S")
    common/Ytunnus                           (g/always "0000000-0")
    common/Verkkolaskuosoite                 (g/always "003712345671")
-   common/Date                              (g/always (java.time.LocalDate/now))
-   common/Instant                           (g/always (java.time.Instant/now))
+   common/Date                              (g/always (LocalDate/now))
+   common/Instant                           (g/always (Instant/now))
    common/Url                               (g/always "https://example.com")
 
    geo/Maa                                  (test-generators/elements ["FI" "SV"])

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -110,7 +110,6 @@
                                                           :valvoja-id        valvoja-id}
                                                          valvonta-schema/ValvontaSave))]
       (doseq [valvonta valvonnat]
-        ;; Voiko tämän tehdä batch-insertinä, että olisi nopeampi? Onko mitään väliä?
         (valvonta-service/add-valvonta! ts/*db* valvonta))
 
       (let [output (atom [])

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -57,13 +57,47 @@
                  [csv-header-line
                   "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\n"]))))))
 
+(t/deftest valvonta.csv-toimenpidetype-test
+  (t/testing "Every toimenpide created on valvonta results in a row in the csv"
+    (let [toimenpidetype-ids [0 1 2 3 4 5 6 7 8 9 10 11 12 14 15 16 17 18 19 21]
+          valvonta-id (valvonta-service/add-valvonta! ts/*db* {:katuosoite        "Testitie 5"
+                                                               :postinumero       "90100"
+                                                               :ilmoituspaikka-id 0
+                                                               :rakennustunnus    "3139000812"})]
+      (doseq [toimenpidetype-id toimenpidetype-ids]
+        (jdbc/insert! ts/*db*
+                      :vk_toimenpide
+                      {:valvonta_id   valvonta-id
+                       :type_id       toimenpidetype-id
+                       :create_time   (-> (LocalDate/of 2024 3 18)
+                                          (.atStartOfDay (ZoneId/systemDefault))
+                                          .toInstant)
+                       :publish_time  (-> (LocalDate/of 2024 3 18)
+                                          (.atStartOfDay (ZoneId/systemDefault))
+                                          .toInstant)
+                       :deadline_date (LocalDate/of 2024 2 7)
+                       :diaarinumero  "ARA-05.03.01-2024-734"}))
+
+      (let [output (atom [])
+            call-count (atom 0)
+            csv-producer (valvonta-service/csv ts/*db*)]
+        (csv-producer (partial handle-output call-count output))
+
+        (t/is (= (inc (count toimenpidetype-ids))
+                 @call-count)
+              "Call count is how many toimenpidetypes there are plus the header row")
+
+        (t/is (= (inc (count toimenpidetype-ids))
+                 (count @output))
+              "Number of rows in the output is how many toimenpidetypes there are plus the header row")))))
+
 (t/deftest valvonta.csv-generated-valvonnat-test
   (t/testing "Creating csv when there are 100 valvontas returns 101 unique rows with header row included"
     (test-kayttajat/insert-virtu-paakayttaja!
-      {:etunimi  "Asian"
-       :sukunimi "Tuntija"
-       :email    "testi@ara.fi"
-       :puhelin  "0504363675457"
+      {:etunimi    "Asian"
+       :sukunimi   "Tuntija"
+       :email      "testi@ara.fi"
+       :puhelin    "0504363675457"
        :titteli-fi "energia-asiantuntija"
        :titteli-sv "energiexpert"})
     (let [valvonnat (repeatedly 100 #(generator/complete {:ilmoituspaikka-id 1

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -31,33 +31,29 @@
                [csv-header-line]))))
 
   (t/testing "Creating csv when there is one open valvonta contains one content line in csv with its data"
-    (with-bindings {#'time/clock (Clock/fixed (-> (LocalDate/of 2024 3 18)
-                                                  (.atStartOfDay time/timezone)
-                                                  .toInstant)
-                                              time/timezone)}
-      (let [valvonta-id (valvonta-service/add-valvonta! ts/*db* {:katuosoite        "Testitie 5"
-                                                                 :postinumero       "90100"
-                                                                 :ilmoituspaikka-id 0
-                                                                 :rakennustunnus    "3139000812"})
-            start-timestamp (-> (LocalDate/of 2024 3 18)
-                                (.atStartOfDay (ZoneId/systemDefault))
-                                .toInstant)
-            output (atom [])
-            call-count (atom 0)
-            create-csv (valvonta-service/csv ts/*db*)]
-        ;; Start the valvonta
-        (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id   valvonta-id
-                                              :type_id       0
-                                              :create_time   start-timestamp
-                                              :publish_time  start-timestamp
-                                              :deadline_date (LocalDate/of 2024 3 27)
-                                              :diaarinumero  "ARA-05.03.01-2024-159"})
-        (create-csv (partial handle-output call-count output))
+    (let [valvonta-id (valvonta-service/add-valvonta! ts/*db* {:katuosoite        "Testitie 5"
+                                                               :postinumero       "90100"
+                                                               :ilmoituspaikka-id 0
+                                                               :rakennustunnus    "3139000812"})
+          start-timestamp (-> (LocalDate/of 2024 3 18)
+                              (.atStartOfDay (ZoneId/systemDefault))
+                              .toInstant)
+          output (atom [])
+          call-count (atom 0)
+          create-csv (valvonta-service/csv ts/*db*)]
+      ;; Start the valvonta
+      (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id   valvonta-id
+                                            :type_id       0
+                                            :create_time   start-timestamp
+                                            :publish_time  start-timestamp
+                                            :deadline_date (LocalDate/of 2024 3 27)
+                                            :diaarinumero  "ARA-05.03.01-2024-159"})
+      (create-csv (partial handle-output call-count output))
 
-        (t/is (= 2 @call-count))
-        (t/is (= @output
-                 [csv-header-line
-                  "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;;\n"]))))))
+      (t/is (= 2 @call-count))
+      (t/is (= @output
+               [csv-header-line
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;;\n"])))))
 
 (t/deftest valvonta.csv-toimenpidetype-test
   (t/testing "Every toimenpide created on valvonta results in a row in the csv"
@@ -171,74 +167,70 @@
 
 (t/deftest energia-todistus-hankittu-test
   (t/testing "Energiatodistus hankittu column is set for kehotus because energiatodistus was acquired during it"
-    (with-bindings {#'time/clock (Clock/fixed (-> (LocalDate/of 2024 3 20)
-                                                  (.atStartOfDay time/timezone)
-                                                  .toInstant)
-                                              time/timezone)}
-      (let [valvoja-id (test-kayttajat/insert-virtu-paakayttaja!
-                         {:etunimi    "Asian"
-                          :sukunimi   "Tuntija"
-                          :email      "testi@ara.fi"
-                          :puhelin    "0504363675457"
-                          :titteli-fi "energia-asiantuntija"
-                          :titteli-sv "energiexpert"})
-            laatija-id (first (keys (test-data.laatija/generate-and-insert! 1)))
-            rakennustunnus "3139000812"
-            valvonta-id (valvonta-service/add-valvonta! ts/*db* {:katuosoite        "Testitie 5"
-                                                                 :postinumero       "90100"
-                                                                 :ilmoituspaikka-id 0
-                                                                 :rakennustunnus    rakennustunnus
-                                                                 :valvoja-id        valvoja-id})
-            start-timestamp (-> (LocalDate/of 2024 3 18)
+    (let [valvoja-id (test-kayttajat/insert-virtu-paakayttaja!
+                       {:etunimi    "Asian"
+                        :sukunimi   "Tuntija"
+                        :email      "testi@ara.fi"
+                        :puhelin    "0504363675457"
+                        :titteli-fi "energia-asiantuntija"
+                        :titteli-sv "energiexpert"})
+          laatija-id (first (keys (test-data.laatija/generate-and-insert! 1)))
+          rakennustunnus "3139000812"
+          valvonta-id (valvonta-service/add-valvonta! ts/*db* {:katuosoite        "Testitie 5"
+                                                               :postinumero       "90100"
+                                                               :ilmoituspaikka-id 0
+                                                               :rakennustunnus    rakennustunnus
+                                                               :valvoja-id        valvoja-id})
+          start-timestamp (-> (LocalDate/of 2024 3 18)
+                              (.atStartOfDay (ZoneId/systemDefault))
+                              .toInstant)
+          kehotus-timestamp (-> (LocalDate/of 2024 3 20)
                                 (.atStartOfDay (ZoneId/systemDefault))
                                 .toInstant)
-            kehotus-timestamp (-> (LocalDate/of 2024 3 20)
-                                  (.atStartOfDay (ZoneId/systemDefault))
-                                  .toInstant)
-            output (atom [])
-            call-count (atom 0)
-            create-csv (valvonta-service/csv ts/*db*)]
-        ;; Start the valvonta
-        (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id  valvonta-id
-                                              :type_id      0
-                                              :create_time  start-timestamp
-                                              :publish_time start-timestamp
-                                              :diaarinumero "ARA-05.03.01-2024-159"})
+          output (atom [])
+          call-count (atom 0)
+          create-csv (valvonta-service/csv ts/*db*)]
+      ;; Start the valvonta
+      (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id  valvonta-id
+                                            :type_id      0
+                                            :create_time  start-timestamp
+                                            :publish_time start-timestamp
+                                            :diaarinumero "ARA-05.03.01-2024-159"})
 
-        ;; Add kehotus-toimenpide to the valvonta
-        (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id   valvonta-id
-                                              :type_id       2
-                                              :create_time   kehotus-timestamp
-                                              :publish_time  kehotus-timestamp
-                                              :deadline_date (LocalDate/of 2024 3 27)})
+      ;; Add kehotus-toimenpide to the valvonta
+      (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id   valvonta-id
+                                            :type_id       2
+                                            :create_time   kehotus-timestamp
+                                            :publish_time  kehotus-timestamp
+                                            :deadline_date (LocalDate/of 2024 3 27)})
 
-        ;; Create energiatodistus and sign it
-        (let [todistus (-> (test-data.energiatodistus/generate-add 2018 true)
-                           (assoc-in [:perustiedot :rakennustunnus] rakennustunnus))
-              todistus-id (test-data.energiatodistus/insert! [todistus] laatija-id)]
-          (test-data.energiatodistus/sign-at-time! todistus-id
-                                                   laatija-id
-                                                   true
-                                                   (-> (LocalDate/of 2024 3 21)
-                                                       (.atStartOfDay (ZoneId/systemDefault))
-                                                       .toInstant)))
+      ;; Create energiatodistus and sign it
+      (let [todistus (-> (test-data.energiatodistus/generate-add 2018 true)
+                         (assoc-in [:perustiedot :rakennustunnus] rakennustunnus))
+            todistus-id (test-data.energiatodistus/insert! [todistus] laatija-id)]
+        (test-data.energiatodistus/sign-at-time! todistus-id
+                                                 laatija-id
+                                                 true
+                                                 (-> (LocalDate/of 2024 3 21)
+                                                     (.atStartOfDay (ZoneId/systemDefault))
+                                                     .toInstant)))
 
-        ;; Close the valvonta
-        (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id  valvonta-id
-                                              :type_id      5
-                                              :create_time  (-> (LocalDate/of 2024 3 22)
-                                                                (.atStartOfDay (ZoneId/systemDefault))
-                                                                .toInstant)
-                                              :publish_time (-> (LocalDate/of 2024 3 22)
-                                                                (.atStartOfDay (ZoneId/systemDefault))
-                                                                .toInstant)})
+      ;; Close the valvonta
+      (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id  valvonta-id
+                                            :type_id      5
+                                            :create_time  (-> (LocalDate/of 2024 3 22)
+                                                              (.atStartOfDay (ZoneId/systemDefault))
+                                                              .toInstant)
+                                            :publish_time (-> (LocalDate/of 2024 3 22)
+                                                              (.atStartOfDay (ZoneId/systemDefault))
+                                                              .toInstant)})
 
-        (create-csv (partial handle-output call-count output))
+      (create-csv (partial handle-output call-count output))
 
-        (t/is (= 4 @call-count))
-        (t/is (= @output
-                 [csv-header-line
-                  "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
-                  "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
-                  "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-22T02:00;\"Tuntija, Asian\";\n"])
-              "All toimenpiteet for the valvonta are present, energiatodistus is marked being created during kehotus toimenpide")))))
+      (t/is (= 4 @call-count))
+      (t/is (= @output
+               [csv-header-line
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
+                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
+                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-22T02:00;\"Tuntija, Asian\";\n"])
+            "All toimenpiteet for the valvonta are present, energiatodistus is marked being created during kehotus toimenpide"))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -1,0 +1,87 @@
+(ns solita.etp.valvonta-kaytto.valvonta-csv-test
+  (:require [clojure.java.jdbc :as jdbc]
+            [clojure.test :as t]
+            [solita.common.time :as time]
+            [solita.etp.schema.valvonta-kaytto :as valvonta-schema]
+            [solita.etp.service.valvonta-kaytto :as valvonta-service]
+            [solita.etp.test-data.generators :as generator]
+            [solita.etp.test-data.kayttaja :as test-kayttajat]
+            [solita.etp.test-system :as ts])
+  (:import (java.time Clock LocalDate ZoneId)))
+
+(t/use-fixtures :each ts/fixture)
+
+(def csv-header-line "\"id\";\"rakennustunnus\";\"diaarinumero\";\"katuosoite\";\"postinumero\";\"postitoimipaikka\";\"toimenpide-id\";\"toimenpidetyyppi\";\"aika\";\"valvoja\"\n")
+
+(defn handle-output [call-count output line]
+  (swap! output conj line)
+  (swap! call-count inc))
+
+(t/deftest valvonta-csv-test
+  (t/testing "Creating csv when there are no valvonnat returns only the header line"
+    (let [output (atom [])
+          call-count (atom 0)
+          csv-producer (valvonta-service/csv ts/*db*)]
+      (csv-producer (partial handle-output call-count output))
+
+      (t/is (= 1 @call-count))
+      (t/is (= @output
+               [csv-header-line]))))
+
+  (t/testing "Creating csv when there is one open valvonta contains one content line in csv with its data"
+    (with-bindings {#'time/clock (Clock/fixed (-> (LocalDate/of 2024 3 18)
+                                                  (.atStartOfDay time/timezone)
+                                                  .toInstant)
+                                              time/timezone)}
+      (let [valvonta-id (valvonta-service/add-valvonta! ts/*db* {:katuosoite        "Testitie 5"
+                                                                 :postinumero       "90100"
+                                                                 :ilmoituspaikka-id 0
+                                                                 :rakennustunnus    "3139000812"})
+            start-timestamp (-> (LocalDate/of 2024 3 18)
+                                (.atStartOfDay (ZoneId/systemDefault))
+                                .toInstant)
+            output (atom [])
+            call-count (atom 0)
+            csv-producer (valvonta-service/csv ts/*db*)]
+        ;; Start the valvonta
+        (jdbc/insert! ts/*db* :vk_toimenpide {:valvonta_id   valvonta-id
+                                              :type_id       0
+                                              :create_time   start-timestamp
+                                              :publish_time  start-timestamp
+                                              :deadline_date (LocalDate/of 2024 3 27)
+                                              :diaarinumero  "ARA-05.03.01-2024-159"})
+        (csv-producer (partial handle-output call-count output))
+
+        (t/is (= 2 @call-count))
+        (t/is (= @output
+                 [csv-header-line
+                  "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\n"]))))))
+
+(t/deftest valvonta.csv-generated-valvonnat-test
+  (t/testing "Creating csv when there are 100 valvontas returns 101 unique rows with header row included"
+    (test-kayttajat/insert-virtu-paakayttaja!
+      {:etunimi  "Asian"
+       :sukunimi "Tuntija"
+       :email    "testi@ara.fi"
+       :puhelin  "0504363675457"
+       :titteli-fi "energia-asiantuntija"
+       :titteli-sv "energiexpert"})
+    (let [valvonnat (repeatedly 100 #(generator/complete {:ilmoituspaikka-id 1
+                                                          :valvoja-id        1}
+                                                         valvonta-schema/ValvontaSave))]
+      (doseq [valvonta valvonnat]
+        ;; Voiko tämän tehdä batch-insertinä, että olisi nopeampi? Onko mitään väliä?
+        (valvonta-service/add-valvonta! ts/*db* valvonta))
+
+      (let [output (atom [])
+            call-count (atom 0)
+            csv-producer (valvonta-service/csv ts/*db*)]
+        (csv-producer (partial handle-output call-count output))
+
+        (t/is (= 101 @call-count))
+
+        (t/is (= (first @output)
+                 csv-header-line))
+
+        (t/is (= (count (set (rest @output)))
+                 100))))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -1,7 +1,6 @@
 (ns solita.etp.valvonta-kaytto.valvonta-csv-test
   (:require [clojure.java.jdbc :as jdbc]
             [clojure.test :as t]
-            [solita.common.time :as time]
             [solita.etp.schema.valvonta-kaytto :as valvonta-schema]
             [solita.etp.service.valvonta-kaytto :as valvonta-service]
             [solita.etp.test-data.energiatodistus :as test-data.energiatodistus]
@@ -9,7 +8,7 @@
             [solita.etp.test-data.kayttaja :as test-kayttajat]
             [solita.etp.test-data.laatija :as test-data.laatija]
             [solita.etp.test-system :as ts])
-  (:import (java.time Clock LocalDate ZoneId)))
+  (:import (java.time LocalDate ZoneId)))
 
 (t/use-fixtures :each ts/fixture)
 

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -30,10 +30,18 @@
                [csv-header-line]))))
 
   (t/testing "Creating csv when there is one open valvonta contains one content line in csv with its data"
+    (test-kayttajat/insert-virtu-paakayttaja!
+      {:etunimi    "Asian"
+       :sukunimi   "Tuntija"
+       :email      "testi@ara.fi"
+       :puhelin    "0504363675457"
+       :titteli-fi "energia-asiantuntija"
+       :titteli-sv "energiexpert"})
     (let [valvonta-id (valvonta-service/add-valvonta! ts/*db* {:katuosoite        "Testitie 5"
                                                                :postinumero       "90100"
                                                                :ilmoituspaikka-id 0
-                                                               :rakennustunnus    "3139000812"})
+                                                               :rakennustunnus    "3139000812"
+                                                               :valvoja-id        1})
           start-timestamp (-> (LocalDate/of 2024 3 18)
                               (.atStartOfDay (ZoneId/systemDefault))
                               .toInstant)
@@ -52,7 +60,7 @@
       (t/is (= 2 @call-count))
       (t/is (= @output
                [csv-header-line
-                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;;\n"])))))
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"])))))
 
 (t/deftest valvonta.csv-toimenpidetype-test
   (t/testing "Every toimenpide created on valvonta results in a row in the csv"
@@ -154,7 +162,8 @@
                                             :publish_time  (-> (LocalDate/of 2024 3 18)
                                                                (.atStartOfDay (ZoneId/systemDefault))
                                                                .toInstant)
-                                            :deadline_date (LocalDate/of 2024 02 14)})
+                                            :deadline_date (LocalDate/of 2024 02 14)
+                                            :diaarinumero  "ARA-05.03.01-2024-159"})
 
       (create-csv (partial handle-output call-count output))
 
@@ -162,7 +171,7 @@
       (t/is (= @output
                [csv-header-line
                 "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
-                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";2;\"Valvonnan lopetus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"])))))
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";2;\"Valvonnan lopetus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"])))))
 
 (t/deftest energiatodistus-hankittu-test
   (t/testing "Energiatodistus hankittu column is set for kehotus because energiatodistus was acquired during it"
@@ -201,7 +210,8 @@
                                             :type_id       2
                                             :create_time   kehotus-timestamp
                                             :publish_time  kehotus-timestamp
-                                            :deadline_date (LocalDate/of 2024 3 27)})
+                                            :deadline_date (LocalDate/of 2024 3 27)
+                                            :diaarinumero  "ARA-05.03.01-2024-159"})
 
       ;; Create energiatodistus and sign it
       (let [todistus (-> (test-data.energiatodistus/generate-add 2018 true)
@@ -222,7 +232,8 @@
                                                               .toInstant)
                                             :publish_time (-> (LocalDate/of 2024 3 22)
                                                               (.atStartOfDay (ZoneId/systemDefault))
-                                                              .toInstant)})
+                                                              .toInstant)
+                                            :diaarinumero "ARA-05.03.01-2024-159"})
 
       (create-csv (partial handle-output call-count output))
 
@@ -230,8 +241,8 @@
       (t/is (= @output
                [csv-header-line
                 "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
-                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
-                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-22T02:00;\"Tuntija, Asian\";\n"])
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-22T02:00;\"Tuntija, Asian\";\n"])
             "All toimenpiteet for the valvonta are present, energiatodistus is marked being created during kehotus toimenpide"))))
 
 
@@ -272,7 +283,8 @@
                                             :type_id       2
                                             :create_time   kehotus-timestamp
                                             :publish_time  kehotus-timestamp
-                                            :deadline_date (LocalDate/of 2024 3 27)})
+                                            :deadline_date (LocalDate/of 2024 3 27)
+                                            :diaarinumero  "ARA-05.03.01-2024-159"})
 
       ;; Create energiatodistus and sign it, the signing time is on the same day as the kehotus deadline
       (let [todistus (-> (test-data.energiatodistus/generate-add 2018 true)
@@ -293,7 +305,8 @@
                                                               .toInstant)
                                             :publish_time (-> (LocalDate/of 2024 3 30)
                                                               (.atStartOfDay (ZoneId/systemDefault))
-                                                              .toInstant)})
+                                                              .toInstant)
+                                            :diaarinumero "ARA-05.03.01-2024-159"})
 
       (create-csv (partial handle-output call-count output))
 
@@ -301,8 +314,8 @@
       (t/is (= @output
                [csv-header-line
                 "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
-                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
-                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-30T02:00;\"Tuntija, Asian\";\n"])
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-30T02:00;\"Tuntija, Asian\";\n"])
             "All toimenpiteet for the valvonta are present, energiatodistus is marked being created during kehotus toimenpide"))))
 
 (t/deftest energiatodistus-hankittu-on-the-day-after-deadline-test
@@ -345,7 +358,8 @@
                                             :type_id       2
                                             :create_time   kehotus-timestamp
                                             :publish_time  kehotus-timestamp
-                                            :deadline_date kehotus-deadline})
+                                            :deadline_date kehotus-deadline
+                                            :diaarinumero  "ARA-05.03.01-2024-159"})
 
       ;; Create energiatodistus and sign it, the signing time is the next day from the deadline
       (let [todistus (-> (test-data.energiatodistus/generate-add 2018 true)
@@ -365,7 +379,7 @@
       (t/is (= @output
                [csv-header-line
                 "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
-                "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\n"])
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\n"])
             "All toimenpiteet for the valvonta are present, energiatodistus is not marked as being created. Exclusive end of the range works correctly with the deadline.")
 
       (t/testing "after the valvonta has been closed, the energiatodistus shows as having been acquired during kehotus"
@@ -377,7 +391,8 @@
                                                                 .toInstant)
                                               :publish_time (-> (.plusDays kehotus-deadline 2)
                                                                 (.atStartOfDay (ZoneId/systemDefault))
-                                                                .toInstant)})
+                                                                .toInstant)
+                                              :diaarinumero "ARA-05.03.01-2024-159"})
 
         ;; Reset the test state
         (reset! call-count 0)
@@ -392,7 +407,6 @@
         (t/is (= @output
                  [csv-header-line
                   "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
-                  "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
-                  "1;\"3139000812\";;\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-29T02:00;\"Tuntija, Asian\";\n"])
-              "All toimenpiteet for the valvonta are present, energiatodistus is marked being created during kehotus as it's created before the next toimenpide"))
-      )))
+                  "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
+                  "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-29T02:00;\"Tuntija, Asian\";\n"])
+              "All toimenpiteet for the valvonta are present, energiatodistus is marked being created during kehotus as it's created before the next toimenpide")))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -194,6 +194,7 @@
           kehotus-timestamp (-> (LocalDate/of 2024 3 20)
                                 (.atStartOfDay (ZoneId/systemDefault))
                                 .toInstant)
+          kehotus-deadline-date (LocalDate/of 2024 3 27)
           close-timestamp (-> (LocalDate/of 2024 3 22)
                               (.atStartOfDay (ZoneId/systemDefault))
                               .toInstant)
@@ -212,7 +213,7 @@
                                             :type_id       2
                                             :create_time   kehotus-timestamp
                                             :publish_time  kehotus-timestamp
-                                            :deadline_date (LocalDate/of 2024 3 27)
+                                            :deadline_date kehotus-deadline-date
                                             :diaarinumero  "ARA-05.03.01-2024-159"})
 
       ;; Create energiatodistus and sign it
@@ -223,7 +224,8 @@
         (test-data.energiatodistus/sign-at-time! todistus-id
                                                  laatija-id
                                                  true
-                                                 (-> (LocalDate/of 2024 3 21)
+                                                 (-> kehotus-deadline-date
+                                                     (.minusDays 3)
                                                      (.atStartOfDay (ZoneId/systemDefault))
                                                      .toInstant)))
 


### PR DESCRIPTION
Add to käytönvalvonta csv information during what toimenpide energiatodistus was acquired during the valvonta, if energiatodistus has been acquired for the building.