### PR TITLE
Remove autoprefixer

### DIFF
--- a/etp-public/package-lock.json
+++ b/etp-public/package-lock.json
@@ -23,7 +23,6 @@
         "@babel/plugin-transform-runtime": "^7.11.5",
         "@babel/preset-env": "^7.11.5",
         "@babel/register": "^7.11.6",
-        "autoprefixer": "^9.8.6",
         "babel-loader": "^9.0.0",
         "chai": "^4.2.0",
         "clean-webpack-plugin": "^4.0.0",

--- a/etp-public/package.json
+++ b/etp-public/package.json
@@ -18,7 +18,6 @@
     "@babel/plugin-transform-runtime": "^7.11.5",
     "@babel/preset-env": "^7.11.5",
     "@babel/register": "^7.11.6",
-    "autoprefixer": "^9.8.6",
     "babel-loader": "^9.0.0",
     "chai": "^4.2.0",
     "clean-webpack-plugin": "^4.0.0",

--- a/etp-public/postcss.config.js
+++ b/etp-public/postcss.config.js
@@ -7,7 +7,6 @@ module.exports = {
   plugins: [
     require('tailwindcss'),
     postcssPresetEnv(),
-    require('autoprefixer'),
     ...(production ? [cssnano('default')] : [])
   ]
 };


### PR DESCRIPTION
Autoprefixer is already included in postcss-preset-env. No need to bring it in separately.