### PR TITLE
Remove dynamic generation of Tailwind classes

### DIFF
--- a/etp-public/src/components/button.svelte
+++ b/etp-public/src/components/button.svelte
@@ -1,8 +1,8 @@
 <script context="module">
   export const styles = {
-    green: { text: 'white', bg: 'green', focus: 'darkgreen' },
-    white: { text: 'ashblue', bg: 'white', focus: 'grey' },
-    ashblue: { text: 'white', bg: 'ashblue', focus: 'darkashblue' }
+    green: { text: 'text-white', bg: 'bg-green', focus: 'bg-darkgreen' },
+    white: { text: 'text-ashblue', bg: 'bg-white', focus: 'bg-grey' },
+    ashblue: { text: 'text-white', bg: 'bg-ashblue', focus: 'bg-darkashblue' }
   };
 </script>
 
@@ -25,6 +25,7 @@
       inset 0 0 0 3px #fff,
       0 0 0 1px #979797;
   }
+
   button.bg-white:focus:not(:disabled),
   button.bg-white:active:not(:disabled),
   button.bg-white:hover:not(:disabled) {
@@ -37,10 +38,12 @@
   .bg-ashblue:focus {
     @apply bg-darkashblue;
   }
+
   .bg-green:hover,
   .bg-green:focus {
     @apply bg-darkgreen;
   }
+
   @media print {
     button {
       display: none;
@@ -56,8 +59,8 @@
   class:bg-lightgrey={disabled}
   class:cursor-not-allowed={disabled}
   class:shadow-none={disabled}
-  class={`inline-flex space-x-3 items-center m-1 uppercase text-sm font-bold tracking-wider rounded-full px-8 py-3 focus:outline-none text-${text} bg-${bg} hover:bg-${
-    disabled ? 'lightgrey' : focus
-  } focus:bg-${disabled ? 'lightgrey' : focus} border-transparent`}>
+  class={`inline-flex space-x-3 items-center m-1 uppercase text-sm font-bold tracking-wider rounded-full px-8 py-3 focus:outline-none ${text} ${bg} hover:${
+    disabled ? 'bg-lightgrey' : focus
+  } focus:${disabled ? 'bg-lightgrey' : focus} border-transparent`}>
   <slot />
 </button>

--- a/etp-public/src/components/buttonlink.svelte
+++ b/etp-public/src/components/buttonlink.svelte
@@ -1,8 +1,8 @@
 <script context="module">
   export const styles = {
-    green: { text: 'white', bg: 'green', focus: 'darkgreen' },
-    white: { text: 'ashblue', bg: 'white', focus: 'grey' },
-    ashblue: { text: 'white', bg: 'ashblue', focus: 'darkashblue' }
+    green: { text: 'text-white', bg: 'bg-green', focus: 'bg-darkgreen' },
+    white: { text: 'text-ashblue', bg: 'bg-white', focus: 'bg-grey' },
+    ashblue: { text: 'text-white', bg: 'bg-ashblue', focus: 'bg-darkashblue' }
   };
 </script>
 
@@ -49,6 +49,6 @@
 <a
   {href}
   {target}
-  class={`inline-flex m-1 uppercase text-sm font-bold tracking-wider rounded-full px-8 py-3 focus:outline-none text-${text} bg-${bg} hover:bg-${focus} focus:bg-${focus} space-x-3 items-center`}>
+  class={`inline-flex m-1 uppercase text-sm font-bold tracking-wider rounded-full px-8 py-3 focus:outline-none ${text} ${bg} hover:${focus} focus:${focus} space-x-3 items-center`}>
   <slot />
 </a>

--- a/etp-public/src/components/container.svelte
+++ b/etp-public/src/components/container.svelte
@@ -1,12 +1,12 @@
 <script context="module">
   export const styles = {
-    beige: { background: 'beige' },
-    mainnavigation: { background: 'mainnavigation' },
-    ashbluewhite: { background: 'ashbluewhite' },
-    grey: { background: 'grey' },
-    white: { background: 'white' },
-    hero: { background: 'heroblurred' },
-    red: { background: 'red' }
+    beige: { background: 'bg-beige' },
+    mainnavigation: { background: 'bg-mainnavigation' },
+    ashbluewhite: { background: 'bg-ashbluewhite' },
+    grey: { background: 'bg-grey' },
+    white: { background: 'bg-white' },
+    hero: { background: 'bg-heroblurred' },
+    red: { background: 'bg-red' }
   };
 </script>
 
@@ -43,7 +43,7 @@
   }
 </style>
 
-<div class="bg-{background}">
+<div class={background}>
   <div class="mx-auto xxl:container">
     <slot />
   </div>

--- a/etp-public/src/components/nav-button.svelte
+++ b/etp-public/src/components/nav-button.svelte
@@ -1,20 +1,28 @@
 <script context="module">
   export const styles = {
     lightgreen: {
-      text: 'black',
-      background: 'lightgreen'
+      text: 'text-black',
+      border: 'border-black',
+      lg_border: 'border-lightgreen',
+      background: 'bg-lightgreen'
     },
     green: {
-      text: 'white',
-      background: 'green'
+      text: 'text-white',
+      border: 'border-white',
+      lg_border: 'border-green',
+      background: 'bg-green'
     },
     darkgreen: {
-      text: 'white',
-      background: 'altgreen'
+      text: 'text-white',
+      border: 'border-white',
+      lg_border: 'border-altgreen',
+      background: 'bg-altgreen'
     },
     ashblue: {
-      text: 'white',
-      background: 'ashblue'
+      text: 'text-white',
+      border: 'border-white',
+      lg_border: 'border-ashblue',
+      background: 'bg-ashblue'
     }
   };
 </script>
@@ -36,11 +44,11 @@
 
 <a
   class="flex box-border lg:flex-full flex-auto py-4 xl:py-6 px-2 navcontainer
-  bg-{background} text-{text} border-{text} focus:z-10 hover:z-10 hover:underline
+  {background} {text} {text} focus:z-10 hover:z-10 hover:underline
   focus:outline-none xl:flex-row lg:flex-col flex-row lg:items-center
   xl:items-center md:items-start {$activePath === link
     ? 'border-l-4'
-    : 'border-l-0'} lg:border-l-0 lg:border-{background} focus:underline"
+    : 'border-l-0'} lg:border-l-0 lg:{background} focus:underline"
   class:shadow-lightgreen={$activePath === link && background === 'lightgreen'}
   class:shadow-green={$activePath === link && background === 'green'}
   class:shadow-altgreen={$activePath === link && background === 'altgreen'}


### PR DESCRIPTION
Earlier some Tailwind class names were generated dynamically, which broke some styles when purge comments were removed.

Simplify code by removing dynamic name generation.