### PR TITLE
AE-2191: Use only templates marked as valid to determine the default template for käytönvalvonta toimenpide

### DIFF
--- a/etp-front/src/pages/valvonta-kaytto/toimenpiteet.js
+++ b/etp-front/src/pages/valvonta-kaytto/toimenpiteet.js
@@ -93,7 +93,11 @@ export const i18nKey = (toimenpide, key) =>
   ]);
 
 const defaultTemplateId = (typeId, templatesByType) => {
-  const templates = R.defaultTo([], templatesByType[typeId]);
+  const templates = R.filter(
+    R.propEq(true, 'valid'),
+    R.defaultTo([], templatesByType[typeId])
+  );
+
   return R.length(templates) === 1
     ? Maybe.Some(R.head(templates).id)
     : Maybe.None();


### PR DESCRIPTION
AE-2191: Use only templates marked as valid to determine the default template for käytönvalvonta toimenpide

- Previously there have been multiple templates in use for some toimenpidetypes. These have now been marked as no longer valid so they can't be selected, but they were still taken into account when determining the default template (the only one when there's no others)