### PR TITLE
Set explicit input placeholder opacity

### DIFF
--- a/etp-public/src/components/input-search.svelte
+++ b/etp-public/src/components/input-search.svelte
@@ -22,7 +22,7 @@
   }
 
   input::placeholder {
-    @apply text-black;
+    @apply text-black/70;
   }
 </style>
 


### PR DESCRIPTION
Tailwind upgrade moved opacity to text-[color]/[opacity] format. As a consequence, placeholder text got default opacity of 100%, whereas before it was determined by browser defaults.

Fixed by setting a sensible looking opacity of 70% for placeholder text.