### PR TITLE
AE-2063: Use toimenpide create time to determine the next toimenpide instead of deadline date when checking if energiatodistus was acquired during a toimenpide

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto.clj
@@ -418,7 +418,7 @@
            left join lateral (select next_toimenpide.create_time
                                      from vk_toimenpide as next_toimenpide
                                      where next_toimenpide.valvonta_id = valvonta.id
-                                     and next_toimenpide.create_time > toimenpide.deadline_date
+                                     and next_toimenpide.create_time > toimenpide.create_time
                                      order by create_time asc
                                      limit 1) as next_toimenpide on true
            left join lateral (select energiatodistus.id

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_csv_test.clj
@@ -195,7 +195,8 @@
                                 (.atStartOfDay (ZoneId/systemDefault))
                                 .toInstant)
           kehotus-deadline-date (LocalDate/of 2024 3 27)
-          close-timestamp (-> (LocalDate/of 2024 3 22)
+          close-timestamp (-> kehotus-deadline-date
+                              (.plusDays 1)
                               (.atStartOfDay (ZoneId/systemDefault))
                               .toInstant)
           output (atom [])
@@ -243,7 +244,7 @@
                [csv-header-line
                 "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";1;\"Valvonnan aloitus\";2024-03-18T02:00;\"Tuntija, Asian\";\n"
                 "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";2;\"Kehotus\";2024-03-20T02:00;\"Tuntija, Asian\";\"x\"\n"
-                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-22T02:00;\"Tuntija, Asian\";\n"])
+                "1;\"3139000812\";\"ARA-05.03.01-2024-159\";\"Testitie 5\";\"90100\";\"OULU\";3;\"Valvonnan lopetus\";2024-03-28T02:00;\"Tuntija, Asian\";\n"])
             "All toimenpiteet for the valvonta are present, energiatodistus is marked being created during kehotus toimenpide"))))
 
 


### PR DESCRIPTION
AE-2063: Use toimenpide create time to determine the next toimenpide instead of deadline date when checking if energiatodistus was acquired during a toimenpide

- This should properly limit the timeframe that energiatodistus is only marked for single toimenpide in a valvonta