### PR TITLE
Fix letter spacing on language select in etp-front

### DIFF
--- a/etp-front/src/pages/header/language-select.svelte
+++ b/etp-front/src/pages/header/language-select.svelte
@@ -13,7 +13,7 @@
   }
 
   div {
-    @apply font-light text-sm;
+    @apply font-light text-sm tracking-normal;
     min-width: 100px;
   }
 </style>


### PR DESCRIPTION
Broken in Tailwind upgrade for unknown reason.