### PR TITLE
Fix unread symbol on messages

### DIFF
--- a/etp-front/src/pages/viesti/viestiketju.svelte
+++ b/etp-front/src/pages/viesti/viestiketju.svelte
@@ -83,7 +83,8 @@
     <div class="flex flex-col w-2/12">
       <span class="block">
         <span
-          class="font-icon outline mr-1 text-primary"
+          class="font-icon outline mr-1"
+          class:text-primary={!unread}
           class:text-error={unread}>
           chat
         </span>


### PR DESCRIPTION
It seems after Tailwind upgrade if both text-primary and text-error are set former wins instead of latter.

Fixed by setting only one of the classes.