### PR TITLE
Fix energiatodistushaku infinite loop

### DIFF
--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/querybuilder/queryblock.svelte
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/querybuilder/queryblock.svelte
@@ -52,8 +52,10 @@
 
   $: if (Maybe.isSome(maybeKey)) {
     tick().then(() => {
-      input.value = Maybe.get(maybeKey);
-      input.dispatchEvent(new Event('change', { bubbles: true }));
+      if (input.value !== Maybe.get(maybeKey)) {
+        input.value = Maybe.get(maybeKey);
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      }
     });
   }
 


### PR DESCRIPTION
After Webpack 5 upgrade something broke, update that queryblock sends causes it to trigger again.

Fixed by not sending the event input value is the same as before.