### PR TITLE
AE-2219: Fix energiatodistus search operator not updating based on selection in etp-front

### DIFF
--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/querybuilder/query-input.svelte
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/querybuilder/query-input.svelte
@@ -82,7 +82,7 @@
     }
   };
 
-  $: op = R.compose(
+  let op = R.compose(
     Maybe.orSome(R.head(operations)),
     Maybe.fromNull,
     R.find(R.pathEq(operation, ['operation', 'browserCommand']))


### PR DESCRIPTION
AE-2219: Fix energiatodistus search operator not updating based on selection in etp-front

- Something broke in webpack upgrade that made (perhaps already buggy?) implementation not change the model to the selected operation
- op was updated on every render reactively back to the default value. Make it not reactive so it's updated as it should