### PR TITLE
Fix valvontamuistio

### DIFF
--- a/etp-front/src/pages/valvonta-oikeellisuus/existing-toimenpide.svelte
+++ b/etp-front/src/pages/valvonta-oikeellisuus/existing-toimenpide.svelte
@@ -68,7 +68,7 @@
     );
   };
 
-  $: load(params);
+  load(params);
 
   const fork = (key, successCallback) => future => {
     overlay = true;


### PR DESCRIPTION
Broken in the Webpack 5 upgrade commit. Perhaps load and save got called in different order earlier.

saveToimenpide calls load so there is no need for reactive load. Fixed by setting it to call only on page load.