### PR TITLE
Implement audit logging for signatures

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/common/audit_log.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/common/audit_log.clj
@@ -1,0 +1,22 @@
+(ns solita.etp.common.audit-log
+  (:require [clojure.tools.logging :as log]))
+
+(def audit-logger "logger.audit.signing")                          ; References logback.xml
+
+(defn print-audit-str
+  "Like print-str, but prints only message from throwables"
+  [& xs]
+  (->> xs
+       (map (fn [x] (if (instance? Throwable x)
+                      (.getMessage x)
+                      x)))
+       (#(with-out-str
+           (apply print %)))))
+
+(defmacro audit-log [level msg & args]
+  `(log/log audit-logger ~level nil (print-audit-str ~msg ~@args)))
+
+(defmacro info
+  {:arglists '([message & more] [throwable message & more])}
+  [& args]
+  `(audit-log :info ~@args))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/core.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/core.clj
@@ -1,9 +1,12 @@
 (ns solita.etp.core
-  (:require [solita.etp.system :as system]))
+  (:require
+    [solita.etp.common.audit-log :as audit-log]
+    [solita.etp.system :as system]))
 
 (defn add-shutdown-hook! [f]
   (.addShutdownHook (Runtime/getRuntime) (Thread. f)))
 
 (defn -main []
   (let [system (system/start!)]
+    (audit-log/info "Starting ETP backend")
     (add-shutdown-hook! #(system/halt! system))))

--- a/etp-core/etp-backend/src/main/resources/logback.xml
+++ b/etp-core/etp-backend/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
     </appender>
     <appender name="appender.audit.signing" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>SIGNATURE_AUDIT_LOG - %d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
+            <pattern>SIGNATURE_AUDIT_LOGS - %d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
         </encoder>
     </appender>
     <logger name="logger.audit.signing" level="INFO" additivity="false">

--- a/etp-core/etp-backend/src/main/resources/logback.xml
+++ b/etp-core/etp-backend/src/main/resources/logback.xml
@@ -4,6 +4,14 @@
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{10} - %msg%n</pattern>
         </encoder>
     </appender>
+    <appender name="appender.audit.signing" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>SIGNATURE_AUDIT_LOG - %d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="logger.audit.signing" level="INFO" additivity="false">
+        <appender-ref ref="appender.audit.signing" />
+    </logger>
 
     <logger name="org.apache.pdfbox.pdmodel.interactive.digitalsignature.visible" level="WARN" />
     <logger name="com.openhtmltopdf" level="WARN" />

--- a/etp-core/etp-backend/src/test/resources/logback.xml
+++ b/etp-core/etp-backend/src/test/resources/logback.xml
@@ -7,7 +7,7 @@
 
     <appender name="appender.audit.signing" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>SIGNATURE_AUDIT_LOG - %d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
+            <pattern>SIGNATURE_AUDIT_LOGS - %d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
         </encoder>
     </appender>
     <logger name="logger.audit.signing" level="INFO" additivity="false">

--- a/etp-core/etp-backend/src/test/resources/logback.xml
+++ b/etp-core/etp-backend/src/test/resources/logback.xml
@@ -5,6 +5,15 @@
         </encoder>
     </appender>
 
+    <appender name="appender.audit.signing" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>SIGNATURE_AUDIT_LOG - %d{HH:mm:ss.SSS} [%thread] %-5level - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <logger name="logger.audit.signing" level="INFO" additivity="false">
+        <appender-ref ref="appender.audit.signing" />
+    </logger>
+
     <logger name="org.apache.pdfbox.pdmodel.interactive.digitalsignature.visible" level="WARN" />
     <logger name="com.openhtmltopdf" level="WARN" />
     <root level="info">


### PR DESCRIPTION
Logger in audit-log ns can be used to log with a known prefix. The logs are then redirected to a different place in AWS.