### PR TITLE
Consider the voimassaolo_paattymisaika as exact timestamp

### DIFF
--- a/etp-core/etp-backend/src/main/sql/solita/etp/db/energiatodistus-destruction.sql
+++ b/etp-core/etp-backend/src/main/sql/solita/etp/db/energiatodistus-destruction.sql
@@ -7,7 +7,7 @@ from energiatodistus
                     from vo_toimenpide
                     group by energiatodistus_id) latest_toimenpide
                    on energiatodistus.id = latest_toimenpide.energiatodistus_id
-where voimassaolo_paattymisaika::date < (now() at time zone 'Europe/Helsinki')::date
+where voimassaolo_paattymisaika < now()
   and ((latest_toimenpide_create_time < (now() at time zone 'Europe/Helsinki')::date - interval '2 years'
         or latest_toimenpide_create_time is null)
       and (latest_toimenpide_publish_time < (now() at time zone 'Europe/Helsinki')::date - interval '2 years'


### PR DESCRIPTION
voimassaolo_paattymisaika is timestamptz and now() returns a timestamptz so there is no need to convert the timezone.