### PR TITLE
Add new internal endpoint for updating public csv data into S3

### DIFF
--- a/etp-core/etp-backend/src/dev/clj/user.clj
+++ b/etp-core/etp-backend/src/dev/clj/user.clj
@@ -85,6 +85,6 @@
 (defn generate-aineisto!
   "Generates the aineisto with `aineisto-id` into aws-s3-client"
   [aineisto-id]
-  (require 'solita.etp.service.aineisto)
-  ((resolve 'solita.etp.service.aineisto/update-aineisto-in-s3!)
+  (require 'solita.etp.service.csv-to-s3)
+  ((resolve 'solita.etp.service.csv-to-s3/update-aineisto-in-s3!)
    (db 2) {:id -5 :rooli -1} (aws-s3-client) aineisto-id))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/api/aineisto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/api/aineisto.clj
@@ -10,6 +10,7 @@
             [solita.etp.schema.common :as common-schema]
             [solita.etp.service.aineisto :as aineisto-service]
             [solita.etp.service.rooli :as rooli-service]
+            [solita.etp.service.csv-to-s3 :as csv-to-s3-service]
             [solita.etp.service.kayttaja :as kayttaja-service]))
 
 (defn first-address [x-forwarded-for]
@@ -65,7 +66,7 @@
              :handler    (fn [{:keys [db whoami aws-s3-client]}]
                            (r/response
                              (concurrent/run-background
-                               #(aineisto-service/update-aineistot-in-s3!
+                               #(csv-to-s3-service/update-aineistot-in-s3!
                                   db
                                   whoami
                                   aws-s3-client)

--- a/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
@@ -2,8 +2,7 @@
   (:require    [ring.util.response :as r]
                [solita.etp.security :as security]
                [solita.etp.service.concurrent :as concurrent]
-               [solita.etp.service.csv-to-s3 :as csv-to-s3]
-               [solita.etp.service.kayttaja :as kayttaja-service]))
+               [solita.etp.service.csv-to-s3 :as csv-to-s3]))
 
 
 (def internal-routes
@@ -20,4 +19,4 @@
                                whoami
                                aws-s3-client
                                {:where nil})
-                             "Aineistot update failed")))}}]]])
+                             "Public csv update failed")))}}]]])

--- a/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
@@ -2,7 +2,7 @@
   (:require    [ring.util.response :as r]
                [solita.etp.security :as security]
                [solita.etp.service.concurrent :as concurrent]
-               [solita.etp.service.aineisto :as aineisto-service]
+               [solita.etp.service.csv-to-s3 :as csv-to-s3]
                [solita.etp.service.kayttaja :as kayttaja-service]))
 
 
@@ -17,7 +17,7 @@
              :handler    (fn [{:keys [db whoami aws-s3-client]}]
                            (r/response
                             (concurrent/run-background
-                             #(aineisto-service/update-public-csv-in-s3!
+                             #(csv-to-s3/update-public-csv-in-s3!
                                db
                                whoami
                                aws-s3-client

--- a/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
@@ -7,7 +7,7 @@
 
 
 (def internal-routes
-  [["public-csv"
+  [["/public-csv"
     ["/update"
      {:post {:summary    "Päivitä julkiset CSV-tiedostot S3:ssa."
              :middleware [[security/wrap-db-application-name

--- a/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
@@ -1,0 +1,25 @@
+(ns solita.etp.api.public-csv
+  (:require    [ring.util.response :as r]
+               [solita.etp.security :as security]
+               [solita.etp.service.concurrent :as concurrent]
+               [solita.etp.service.aineisto :as aineisto-service]
+               [solita.etp.service.kayttaja :as kayttaja-service]))
+
+
+(def internal-routes
+  [["public-csv"
+    ["/update"
+     {:post {:summary    "Päivitä julkiset CSV-tiedostot S3:ssa."
+             :middleware [[security/wrap-db-application-name
+                           (kayttaja-service/system-kayttaja :aineisto)]
+                          [security/wrap-whoami-for-internal-aineisto-api]]
+             :responses  {200 {:body nil}}
+             :handler    (fn [{:keys [db whoami aws-s3-client]}]
+                           (r/response
+                            (concurrent/run-background
+                             #(aineisto-service/update-public-csv-in-s3!
+                               db
+                               whoami
+                               aws-s3-client
+                               {:where nil})
+                             "Aineistot update failed")))}}]]])

--- a/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/api/public_csv.clj
@@ -10,9 +10,7 @@
   [["/public-csv"
     ["/update"
      {:post {:summary    "Päivitä julkiset CSV-tiedostot S3:ssa."
-             :middleware [[security/wrap-db-application-name
-                           (kayttaja-service/system-kayttaja :aineisto)]
-                          [security/wrap-whoami-for-internal-aineisto-api]]
+             :middleware [[security/wrap-db-application-name]]
              :responses  {200 {:body nil}}
              :handler    (fn [{:keys [db whoami aws-s3-client]}]
                            (r/response

--- a/etp-core/etp-backend/src/main/clj/solita/etp/handler.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/handler.clj
@@ -17,6 +17,7 @@
             [ring.middleware.cookies :as cookies]
             [schema.coerce]
             [schema.core]
+            [solita.etp.api.public-csv :as public-csv-api]
             [schema.core :as s]
             [solita.etp.api.aineisto :as aineisto-api]
             [solita.etp.api.energiatodistus :as energiatodistus-api]
@@ -169,7 +170,8 @@
      (concat (tag "Laskutus API" laskutus-api/routes)
              (tag "Laatija Internal API" laatija-api/internal-routes)
              (tag "Energiatodistus Internal API" energiatodistus-api/internal-routes)
-             (tag "Aineisto Internal API" aineisto-api/internal-routes))]]
+             (tag "Aineisto Internal API" aineisto-api/internal-routes)
+             (tag "Public csv Internal API" public-csv-api/internal-routes))]]
    (when config/allow-palveluvayla-api
      ["/palveluvayla" ["/openapi.json" {:get {:no-doc  true :openapi {:info {:title "Energiatodistuspalvelu API" :description "Hae energiatodistuksia pdf tai json muodoissa"}
                                                                       :id   "Palveluväylä"}

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
@@ -94,45 +94,4 @@
     (not-nil-aineisto-source val)
     (val db whoami)))
 
-(defn update-aineisto-in-s3! [db whoami aws-s3-client aineisto-id]
-  (log/info (str "Starting updating of aineisto (id: " aineisto-id ")."))
-  (let [csv-reducible-query (aineisto-reducible-query db whoami aineisto-id)
-        key (str "/api/signed/aineistot/" aineisto-id "/energiatodistukset.csv")
-        ;; This part is used to store rows until it reaches 5MB which
-        ;; is the minimum requirement by `upload-part-fn`.
-        current-part (ByteBuffer/allocate (* 8 1024 1024))
-        upload-parts-fn (fn [upload-part-fn]
-                          (csv-reducible-query (fn [^String row]
-                                                 (let [row-bytes (.getBytes row StandardCharsets/UTF_8)]
-                                                   (.put current-part row-bytes)
-                                                   (when (< (* 5 1024 1024) (.position current-part))
-                                                     (upload-part-fn (extract-byte-array-and-reset! current-part))))))
-                          ;;The last part needs to be uploaded separately (unless the size was a multiple of 5MB)
-                          (when (not= 0 (.position current-part))
-                            (upload-part-fn (extract-byte-array-and-reset! current-part))))]
-    (file/upsert-file-in-parts aws-s3-client key upload-parts-fn)
-    (log/info (str "Updating of aineisto (id: " aineisto-id ") finished."))))
-
-(defn update-public-csv-in-s3! [db whoami aws-s3-client query]
-  (log/info "Starting updating of public energiato.")
-  (let [csv-reducible-query (energiatodistus-csv/energiatodistukset-public-csv db whoami query)
-        key "/api/csv/public/energiatodistukset.csv"
-        ;; Allocate an 8MB ByteBuffer to store CSV rows until it reaches 5MB
-        current-part (ByteBuffer/allocate (* 8 1024 1024))
-        upload-parts-fn (fn [upload-part-fn]
-                          (csv-reducible-query (fn [^String row]
-                                                 (let [row-bytes (.getBytes row StandardCharsets/UTF_8)]
-                                                   (.put current-part row-bytes)
-                                                   (when (> (.position current-part) (* 5 1024 1024))
-                                                     (upload-part-fn (extract-byte-array-and-reset! current-part))))))
-                          ;; Upload the last part if it doesn't reach 5MB
-                          (when (not= 0 (.position current-part))
-                            (upload-part-fn (extract-byte-array-and-reset! current-part))))]
-    (file/upsert-file-in-parts aws-s3-client key upload-parts-fn)
-    (log/info "Updating of public energiato finished.")))
-
-(defn update-aineistot-in-s3! [db whoami aws-s3-client]
-  (update-aineisto-in-s3! db whoami aws-s3-client 1)
-  (update-aineisto-in-s3! db whoami aws-s3-client 2)
-  (update-aineisto-in-s3! db whoami aws-s3-client 3))
 

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/csv_to_s3.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/csv_to_s3.clj
@@ -13,7 +13,7 @@
   (ByteBuffer/allocate buffer-size))
 
 (def public-csv-key
-  "/api/csv/public/energiatodistukset.csv")
+  "/api/public/energiatodistukset/csv/energiatodistukset.csv")
 
 (defn aineisto-key [aineisto-id]
   (str "/api/signed/aineistot/" aineisto-id "/energiatodistukset.csv"))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/csv_to_s3.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/csv_to_s3.clj
@@ -1,0 +1,53 @@
+(ns solita.etp.service.csv-to-s3
+  (:require [clojure.tools.logging :as log]
+            [solita.etp.service.energiatodistus-csv :as energiatodistus-csv]
+            [solita.etp.service.file :as file]
+            [solita.etp.service.aineisto :as aineisto-service])
+  (:import [java.nio ByteBuffer]
+            [java.nio.charset StandardCharsets]))
+
+(def ^:private buffer-size (* 8 1024 1024))  ; 8MB
+(def ^:private upload-threshold (* 5 1024 1024))  ; 5MB
+
+(defn- create-buffer []
+  (ByteBuffer/allocate buffer-size))
+
+(defn- create-upload-parts-fn [csv-reducible-query]
+  (let [current-part (create-buffer)]
+    (fn [upload-part-fn]
+      (csv-reducible-query
+       (fn [^String row]
+         (let [row-bytes (.getBytes row StandardCharsets/UTF_8)]
+           (.put current-part row-bytes)
+           (when (> (.position current-part) upload-threshold)
+             (upload-part-fn (aineisto-service/extract-byte-array-and-reset! current-part))))))
+      ;; Upload any remaining data
+      (when (not= 0 (.position current-part))
+        (upload-part-fn (aineisto-service/extract-byte-array-and-reset! current-part))))))
+
+(defn- process-csv-to-s3! [aws-s3-client key csv-reducible-query log-start log-end]
+  (log/info log-start)
+  (let [upload-parts-fn (create-upload-parts-fn csv-reducible-query)]
+    (file/upsert-file-in-parts aws-s3-client key upload-parts-fn)
+    (log/info log-end)))
+
+(defn update-aineisto-in-s3! [db whoami aws-s3-client aineisto-id]
+  (let [csv-query (aineisto-service/aineisto-reducible-query db whoami aineisto-id)
+        key (str "/api/signed/aineistot/" aineisto-id "/energiatodistukset.csv")
+        start-msg (str "Starting updating of aineisto (id: " aineisto-id ").")
+        end-msg (str "Updating of aineisto (id: " aineisto-id ") finished.")]
+    (process-csv-to-s3! aws-s3-client key csv-query start-msg end-msg)))
+
+(defn update-public-csv-in-s3! [db whoami aws-s3-client query]
+  (let [csv-query (energiatodistus-csv/energiatodistukset-public-csv db whoami query)
+        key "/api/csv/public/energiatodistukset.csv"]
+    (process-csv-to-s3!
+     aws-s3-client
+     key
+     csv-query
+     "Starting updating of public energiatodistus."
+     "Updating of public energiatodistus finished.")))
+
+(defn update-aineistot-in-s3! [db whoami aws-s3-client]
+  (doseq [id [1 2 3]]
+    (update-aineisto-in-s3! db whoami aws-s3-client id)))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
@@ -100,15 +100,15 @@
 
 (t/deftest update-aineistot-test
   (t/testing "Aineistot don't exist before generating"
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/1/energiatodistukset.csv")))
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/2/energiatodistukset.csv")))
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/3/energiatodistukset.csv"))))
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* (csv-to-s3/aineisto-key 1))))
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* (csv-to-s3/aineisto-key 2))))
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* (csv-to-s3/aineisto-key 3)))))
 
   (t/testing "Aineistot exist after generating"
     (csv-to-s3/update-aineistot-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client*)
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/1/energiatodistukset.csv")))
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/2/energiatodistukset.csv")))
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/3/energiatodistukset.csv"))))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* (csv-to-s3/aineisto-key 1))))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* (csv-to-s3/aineisto-key 2))))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* (csv-to-s3/aineisto-key 3)))))
 
   (t/testing "New energiatodistus shows up correctly when updating aineistot"
     (let [;; Add laatija
@@ -140,18 +140,18 @@
       (csv-to-s3/update-aineistot-in-s3! ts/*db* whoami ts/*aws-s3-client*)
 
       ;; Aineisto 1 - Test that rakennustunnus-1 exists, but that there is only one row of energiatodistukset.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/1/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto (csv-to-s3/aineisto-key 1))]
         (t/is (true? (str/includes? first rakennustunnus-1)))
         (t/is (nil? second)))
 
       ;; Aineisto 2 - Test that rakennustunnus-1 exists, but that there is only one row of energiatodistukset.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/2/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto (csv-to-s3/aineisto-key 2))]
         (t/is (true? (str/includes? first rakennustunnus-1)))
         (t/is (nil? second)))
 
       ;; Aineisto 3 - Test that one row exists and that the rakennustunnus can't be found as this set should be
       ;; anonymized.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/3/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto (csv-to-s3/aineisto-key 3))]
         (t/is (false? (str/includes? first rakennustunnus-1)))
         (t/is (false? (nil? first)))
         (t/is (nil? second)))
@@ -164,19 +164,19 @@
 
       ;; Aineisto 1 - Test that both rakennustunnus exist. It does not matter which one is which
       ;; as the order of them is not guaranteed.
-      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/1/energiatodistukset.csv")]
+      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto (csv-to-s3/aineisto-key 1))]
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-1 csv-et-lines)))
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-2 csv-et-lines))))
 
       ;; Aineisto 2 - Test that both rakennustunnus exist. It does not matter which one is which
       ;; as the order of them is not guaranteed.
-      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/2/energiatodistukset.csv")]
+      (let [csv-et-lines (get-first-two-energiatodistus-lines-from-aineisto (csv-to-s3/aineisto-key 2))]
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-1 csv-et-lines)))
         (t/is (true? (is-included-in-exactly-one? rakennustunnus-2 csv-et-lines))))
 
       ;; Aineisto 3 - Test that two rows exists and that either of the rakennustunnukset can't be found
       ;; as this set is be anonymized.
-      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/3/energiatodistukset.csv")]
+      (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto (csv-to-s3/aineisto-key 3))]
         ;; Rakennustunnus-1 can't be found
         (t/is (false? (str/includes? first rakennustunnus-1)))
         (t/is (false? (str/includes? second rakennustunnus-1)))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
@@ -1,5 +1,6 @@
 (ns solita.etp.service.aineisto-test
   (:require [solita.etp.service.aineisto :as aineisto]
+            [solita.etp.service.csv-to-s3 :as csv-to-s3]
             [solita.etp.service.file :as file]
             [solita.etp.service.kayttaja :as kayttaja-service]
             [solita.etp.test-data.generators :as generators]
@@ -104,7 +105,7 @@
     (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/3/energiatodistukset.csv"))))
 
   (t/testing "Aineistot exist after generating"
-    (aineisto/update-aineistot-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client*)
+    (csv-to-s3/update-aineistot-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client*)
     (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/1/energiatodistukset.csv")))
     (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/2/energiatodistukset.csv")))
     (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/signed/aineistot/3/energiatodistukset.csv"))))
@@ -136,7 +137,7 @@
 
       ;; Update aineistot. Todistus-1 should be included after the update,
       ;; but todistus-2 should be not as it's not signed yet.
-      (aineisto/update-aineistot-in-s3! ts/*db* whoami ts/*aws-s3-client*)
+      (csv-to-s3/update-aineistot-in-s3! ts/*db* whoami ts/*aws-s3-client*)
 
       ;; Aineisto 1 - Test that rakennustunnus-1 exists, but that there is only one row of energiatodistukset.
       (let [[first second] (get-first-two-energiatodistus-lines-from-aineisto "/api/signed/aineistot/1/energiatodistukset.csv")]
@@ -159,7 +160,7 @@
       (test-data.energiatodistus/sign! todistus-2-id laatija-id true)
 
       ;; Update aineistot. Now todistus-1 and todistus-2 should be in the csv.
-      (aineisto/update-aineistot-in-s3! ts/*db* whoami ts/*aws-s3-client*)
+      (csv-to-s3/update-aineistot-in-s3! ts/*db* whoami ts/*aws-s3-client*)
 
       ;; Aineisto 1 - Test that both rakennustunnus exist. It does not matter which one is which
       ;; as the order of them is not guaranteed.

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
@@ -3,10 +3,14 @@
             [solita.etp.service.file :as file]
             [clojure.test :as t]
             [clojure.string :as str]
+            [clojure.data.csv :as csv]
+            [clojure.java.io :as io]
+            [clojure.set :as clojure.set]
+            [solita.etp.test-data.generators :as generators]
             [solita.etp.test-system :as ts]
+            [solita.etp.service.aineisto-test :as aineistot-test]
             [solita.etp.test-data.laatija :as test-data.laatija]
-            [solita.etp.test-data.energiatodistus :as test-data.energiatodistus])
-  (:import (java.io BufferedReader InputStreamReader)))
+            [solita.etp.test-data.energiatodistus :as test-data.energiatodistus]))
 
 (t/use-fixtures :each ts/fixture)
 
@@ -15,57 +19,107 @@
     (t/is (false? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key))))
 
   (t/testing "Public csv exists after generating"
-    (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
+    (csv-to-s3/update-public-csv-in-s3! ts/*db* nil ts/*aws-s3-client* {:where nil})
     (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))))
 
-(defn get-first-two-lines-from-csv [key]
-  (with-open [csv-file (file/find-file ts/*aws-s3-client* key)]
-    (let [reader (BufferedReader. (InputStreamReader. csv-file))
-          ;; CSV headers
-          header (.readLine reader)
-          first-line (.readLine reader)
-          _ (prn "first-line:" first-line)
-          second-line (.readLine reader)]
-      [header first-line second-line])))
+(defn get-first-three-lines-from-csv [key]
+  (with-open [csv-file (file/find-file ts/*aws-s3-client* key)
+              reader (clojure.java.io/reader csv-file)]
+    (let [csv-data (csv/read-csv reader :separator \;)
+          [header first-line second-line third-line] (take 4 csv-data)]
+      [header first-line second-line third-line])))
+
+(defn get-full-csv-content [key]
+  (with-open [csv-file (file/find-file ts/*aws-s3-client* key)
+              reader (io/reader csv-file)]
+    (let [csv-data (doall (csv/read-csv reader :separator \;))]
+      (prn "Debug - Raw CSV data:" csv-data)
+      csv-data)))
 
 (t/deftest test-update-public-csv-in-s3!-handles-empty-query
   (t/testing "CSV contains expected columns when energiatodistus exists"
-    (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
+    (csv-to-s3/update-public-csv-in-s3! ts/*db* nil ts/*aws-s3-client* {:where nil})
     (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))
 
-    (let [[header & _] (get-first-two-lines-from-csv csv-to-s3/public-csv-key)]
-      ;; Verify required columns exist in header with proper path format
-      (t/is (str/includes? header "Perustiedot / Alakayttotarkoitus-fi"))
-      (t/is (str/includes? header "Tulokset / E-luokka-rajat"))
-      (t/is (str/includes? header "Tulokset / Kaytettavat-energiamuodot / Kaukolampo-kerroin"))
+    (let [[header & _] (get-first-three-lines-from-csv csv-to-s3/public-csv-key)
+          header-set (set header)
+          expected-headers #{"Perustiedot / Alakayttotarkoitus-fi"
+                             "Tulokset / E-luokka-rajat"
+                             "Tulokset / Kaytettavat-energiamuodot / Kaukolampo-kerroin"}]
+      ;; Verify required columns exist in header
+      (t/is (clojure.set/subset? expected-headers header-set))
 
-      ;; Verify hidden columns don't exist
-      (t/is (not (str/includes? header "tila-id")))
-      (t/is (not (str/includes? header "laatija-id")))
-      (t/is (not (str/includes? header "yritys"))))))
+      ;; Define hidden headers
+      (let [hidden-headers #{"tila-id" "laatija-id" "yritys"}]
+        ;; Verify hidden columns don't exist
+        (t/is (empty? (clojure.set/intersection hidden-headers header-set)))))))
 
-(t/deftest test-update-public-csv-in-s3!-with-data
-  (let [laatija-id (first (keys (test-data.laatija/generate-and-insert! 1)))
-        energiatodistus (test-data.energiatodistus/generate-and-insert! 1 2018 true laatija-id)]
+(t/deftest test-update-public-csv-in-s3!-with-multiple-data
+  (let [;; Generate three different rakennustunnus
+        rakennustunnus-1 (generators/generate-rakennustunnus)
+        rakennustunnus-2 (generators/generate-rakennustunnus)
+        rakennustunnus-3 (generators/generate-rakennustunnus)
 
-     ;; Debug prints to verify test data
-    (prn "Debug - Created laatija-id:" laatija-id)
-    (prn "Debug - Created energiatodistus:" energiatodistus)
+        ;; Insert laatija and get laatija-id
+        laatija-id (first (keys (test-data.laatija/generate-and-insert! 1)))
 
-    ;; First ensure CSV doesn't exist
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))
+          ;; Define fixed sisainen-kuorma
+        fixed-sisainen-kuorma-pk {:henkilot {:kayttoaste 0.6M, :lampokuorma 14M}
+                                  :kuluttajalaitteet {:kayttoaste 0.6M, :lampokuorma 8M}
+                                  :valaistus {:kayttoaste 0.6M}}
+
+        fixed-sisainen-kuorma-yat {:henkilot {:kayttoaste 0.6M, :lampokuorma 2M}
+                                   :kuluttajalaitteet {:kayttoaste 0.6M, :lampokuorma 3M}
+                                   :valaistus {:kayttoaste 0.1M}}
+
+        ;; Create three energiatodistus:
+        ;; - todistus-1 with kayttotarkoitus "PK"
+        ;; - todistus-2 with kayttotarkoitus "PK"
+        ;; - todistus-3 with kayttotarkoitus "YAT"
+        todistus-1 (-> (test-data.energiatodistus/generate-add 2018 true)
+                       (assoc-in [:perustiedot :rakennustunnus] rakennustunnus-1)
+                       (assoc-in [:perustiedot :kayttotarkoitus] "PK")
+                       (assoc-in [:lahtotiedot :sis-kuorma] fixed-sisainen-kuorma-pk))
+        todistus-2 (-> (test-data.energiatodistus/generate-add 2018 true)
+                       (assoc-in [:perustiedot :rakennustunnus] rakennustunnus-2)
+                       (assoc-in [:perustiedot :kayttotarkoitus] "PK")
+                       (assoc-in [:lahtotiedot :sis-kuorma] fixed-sisainen-kuorma-pk))
+        todistus-3 (-> (test-data.energiatodistus/generate-add 2018 true)
+                       (assoc-in [:perustiedot :rakennustunnus] rakennustunnus-3)
+                       (assoc-in [:perustiedot :kayttotarkoitus] "YAT")
+                       (assoc-in [:lahtotiedot :sis-kuorma] fixed-sisainen-kuorma-yat))
+
+        ;; Insert all three todistus
+        [todistus-1-id] (test-data.energiatodistus/insert! [todistus-1] laatija-id)
+        [todistus-2-id] (test-data.energiatodistus/insert! [todistus-2] laatija-id)
+        [todistus-3-id] (test-data.energiatodistus/insert! [todistus-3] laatija-id)]
+
+    ;; Sign all three todistus
+    (test-data.energiatodistus/sign! todistus-1-id laatija-id true)
+    (test-data.energiatodistus/sign! todistus-2-id laatija-id true)
+    (test-data.energiatodistus/sign! todistus-3-id laatija-id true)
+
+    ;; Ensure CSV doesn't exist before generating
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key))
+          "CSV should not exist before generation.")
 
     ;; Generate CSV
-    (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
+    (csv-to-s3/update-public-csv-in-s3! ts/*db* nil ts/*aws-s3-client* {:where nil})
 
     ;; Verify CSV was created
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key))
+          "CSV should exist after generation.")
 
-    (t/testing "CSV contains expected data from energiatodistus"
-      (let [[header first-line second-line :as lines] (get-first-two-lines-from-csv csv-to-s3/public-csv-key)]
-        (prn "Debug - CSV content:" lines)
-        (t/is (some? header) "Header should exist")
-        (t/is (some? first-line) "First line should exist")
-        (when first-line
-          (t/is (str/includes? first-line (str (:id energiatodistus)))
-                (str "Line should contain energiatodistus id: " (:id energiatodistus))))))))
+    (t/testing "CSV contains only signed energiatodistus data with kayttotarkoitus 'PK' and excludes 'YAT'"
+      ;; Rakennustunnus matches the first generated energiatodistus
+      (let [[_ first _] (get-first-three-lines-from-csv csv-to-s3/public-csv-key)]
+        (t/is (true? (str/includes? first rakennustunnus-1))))
+
+      ;; Rakennustunnus matches the second generated energiatodistus
+      (let [[_ _ second] (get-first-three-lines-from-csv csv-to-s3/public-csv-key)]
+        (t/is (true? (str/includes? second rakennustunnus-2))))
+
+      ;; Rakennustunnus does not match the third generated energiatodistus
+      (let [[_ _ _ third] (get-first-three-lines-from-csv csv-to-s3/public-csv-key)]
+        (t/is (true? (nil? third)))))))
+

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
@@ -8,8 +8,8 @@
 
 (t/deftest test-public-csv-to-s3
   (t/testing "Public csv doesn't exist before generating"
-    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/csv/public/energiatodistukset.csv"))))
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key))))
 
   (t/testing "Public csv exists after generating"
     (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
-    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/csv/public/energiatodistukset.csv")))))
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
@@ -2,7 +2,11 @@
   (:require [solita.etp.service.csv-to-s3 :as csv-to-s3]
             [solita.etp.service.file :as file]
             [clojure.test :as t]
-            [solita.etp.test-system :as ts]))
+            [clojure.string :as str]
+            [solita.etp.test-system :as ts]
+            [solita.etp.test-data.laatija :as test-data.laatija]
+            [solita.etp.test-data.energiatodistus :as test-data.energiatodistus])
+  (:import (java.io BufferedReader InputStreamReader)))
 
 (t/use-fixtures :each ts/fixture)
 
@@ -13,3 +17,55 @@
   (t/testing "Public csv exists after generating"
     (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
     (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))))
+
+(defn get-first-two-lines-from-csv [key]
+  (with-open [csv-file (file/find-file ts/*aws-s3-client* key)]
+    (let [reader (BufferedReader. (InputStreamReader. csv-file))
+          ;; CSV headers
+          header (.readLine reader)
+          first-line (.readLine reader)
+          _ (prn "first-line:" first-line)
+          second-line (.readLine reader)]
+      [header first-line second-line])))
+
+(t/deftest test-update-public-csv-in-s3!-handles-empty-query
+  (t/testing "CSV contains expected columns when energiatodistus exists"
+    (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))
+
+    (let [[header & _] (get-first-two-lines-from-csv csv-to-s3/public-csv-key)]
+      ;; Verify required columns exist in header with proper path format
+      (t/is (str/includes? header "Perustiedot / Alakayttotarkoitus-fi"))
+      (t/is (str/includes? header "Tulokset / E-luokka-rajat"))
+      (t/is (str/includes? header "Tulokset / Kaytettavat-energiamuodot / Kaukolampo-kerroin"))
+
+      ;; Verify hidden columns don't exist
+      (t/is (not (str/includes? header "tila-id")))
+      (t/is (not (str/includes? header "laatija-id")))
+      (t/is (not (str/includes? header "yritys"))))))
+
+(t/deftest test-update-public-csv-in-s3!-with-data
+  (let [laatija-id (first (keys (test-data.laatija/generate-and-insert! 1)))
+        energiatodistus (test-data.energiatodistus/generate-and-insert! 1 2018 true laatija-id)]
+
+     ;; Debug prints to verify test data
+    (prn "Debug - Created laatija-id:" laatija-id)
+    (prn "Debug - Created energiatodistus:" energiatodistus)
+
+    ;; First ensure CSV doesn't exist
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))
+
+    ;; Generate CSV
+    (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
+
+    ;; Verify CSV was created
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* csv-to-s3/public-csv-key)))
+
+    (t/testing "CSV contains expected data from energiatodistus"
+      (let [[header first-line second-line :as lines] (get-first-two-lines-from-csv csv-to-s3/public-csv-key)]
+        (prn "Debug - CSV content:" lines)
+        (t/is (some? header) "Header should exist")
+        (t/is (some? first-line) "First line should exist")
+        (when first-line
+          (t/is (str/includes? first-line (str (:id energiatodistus)))
+                (str "Line should contain energiatodistus id: " (:id energiatodistus))))))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
@@ -1,0 +1,15 @@
+(ns solita.etp.service.csv-to-s3-test
+  (:require [solita.etp.service.csv-to-s3 :as csv-to-s3]
+            [solita.etp.service.file :as file]
+            [clojure.test :as t]
+            [solita.etp.test-system :as ts]))
+
+(t/use-fixtures :each ts/fixture)
+
+(t/deftest test-public-csv-to-s3
+  (t/testing "Public csv doesn't exist before generating"
+    (t/is (false? (file/file-exists? ts/*aws-s3-client* "/api/csv/public/energiatodistukset.csv"))))
+
+  (t/testing "Public csv exists after generating"
+    (csv-to-s3/update-public-csv-in-s3! ts/*db* {:id -5 :rooli 2} ts/*aws-s3-client* {:where nil})
+    (t/is (true? (file/file-exists? ts/*aws-s3-client* "/api/csv/public/energiatodistukset.csv")))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/csv_to_s3_test.clj
@@ -13,6 +13,61 @@
 
 (t/use-fixtures :each ts/fixture)
 
+(def public-columns #{[:id]
+                      [:versio]
+                      [:allekirjoitusaika]
+                      [:voimassaolo-paattymisaika]
+                      [:perustiedot :kieli]
+                      [:perustiedot :laatimisvaihe]
+                      [:perustiedot :havainnointikaynti]
+                      [:perustiedot :nimi-fi]
+                      [:perustiedot :nimi-sv]
+                      [:perustiedot :valmistumisvuosi]
+                      [:perustiedot :katuosoite-fi]
+                      [:perustiedot :katuosoite-sv]
+                      [:perustiedot :postinumero]
+                      [:perustiedot :rakennustunnus]
+                      [:perustiedot :kayttotarkoitus]
+                      [:perustiedot :alakayttotarkoitus-fi]
+                      [:tulokset :e-luku]
+                      [:tulokset :e-luokka]
+                      [:tulokset :e-luokka-rajat :raja-uusi-2018]
+                      [:tulokset :e-luokka-rajat :kayttotarkoitus :label-fi]
+                      [:perustiedot :keskeiset-suositukset-fi]
+                      [:perustiedot :keskeiset-suositukset-sv]
+                      [:lahtotiedot :lammitetty-nettoala]
+                      [:lahtotiedot :ilmanvaihto :tyyppi-id]
+                      [:lahtotiedot :ilmanvaihto :kuvaus-fi]
+                      [:lahtotiedot :ilmanvaihto :kuvaus-sv]
+                      [:lahtotiedot :lammitys :lammitysmuoto-1 :id]
+                      [:lahtotiedot :lammitys :lammitysmuoto-2 :id]
+                      [:lahtotiedot :lammitys :lammitysmuoto-1 :kuvaus-fi]
+                      [:lahtotiedot :lammitys :lammitysmuoto-1 :kuvaus-sv]
+                      [:lahtotiedot :lammitys :lammitysmuoto-2 :kuvaus-fi]
+                      [:lahtotiedot :lammitys :lammitysmuoto-2 :kuvaus-sv]
+                      [:lahtotiedot :lammitys :lammonjako :id]
+                      [:lahtotiedot :lammitys :lammonjako :kuvaus-fi]
+                      [:lahtotiedot :lammitys :lammonjako :kuvaus-sv]
+                      [:tulokset :kaytettavat-energiamuodot :kaukolampo]
+                      [:tulokset :kaytettavat-energiamuodot :kaukolampo-kerroin]
+                      [:tulokset :kaytettavat-energiamuodot :sahko]
+                      [:tulokset :kaytettavat-energiamuodot :sahko-kerroin]
+                      [:tulokset :kaytettavat-energiamuodot :uusiutuva-polttoaine]
+                      [:tulokset :kaytettavat-energiamuodot :uusiutuva-polttoaine-kerroin]
+                      [:tulokset :kaytettavat-energiamuodot :fossiilinen-polttoaine]
+                      [:tulokset :kaytettavat-energiamuodot :fossiilinen-polttoaine-kerroin]
+                      [:tulokset :kaytettavat-energiamuodot :kaukojaahdytys]
+                      [:tulokset :kaytettavat-energiamuodot :kaukojaahdytys-kerroin]
+                      [:tulokset :kaytettavat-energiamuodot :muu 0 :nimi]
+                      [:tulokset :kaytettavat-energiamuodot :muu 0 :ostoenergia]
+                      [:tulokset :kaytettavat-energiamuodot :muu 0 :muotokerroin]
+                      [:tulokset :kaytettavat-energiamuodot :muu 1 :nimi]
+                      [:tulokset :kaytettavat-energiamuodot :muu 1 :ostoenergia]
+                      [:tulokset :kaytettavat-energiamuodot :muu 1 :muotokerroin]
+                      [:tulokset :kaytettavat-energiamuodot :muu 2 :nimi]
+                      [:tulokset :kaytettavat-energiamuodot :muu 2 :ostoenergia]
+                      [:tulokset :kaytettavat-energiamuodot :muu 2 :muotokerroin]})
+
 (defn column-ks->str [ks]
   (->> ks
        (map #(if (keyword? %) (name %) %))
@@ -47,24 +102,15 @@
           "CSV should exist after generation.")
 
     (let [[headers & _] (get-first-three-lines-from-csv csv-to-s3/public-csv-key)
-          extra-columns #{[:perustiedot :alakayttotarkoitus-fi]
-                          [:tulokset :e-luokka-rajat :kayttotarkoitus :label-fi]
-                          [:tulokset :e-luokka-rajat :raja-uusi-2018]
-                          [:tulokset :kaytettavat-energiamuodot :kaukolampo-kerroin]
-                          [:tulokset :kaytettavat-energiamuodot :sahko-kerroin]
-                          [:tulokset :kaytettavat-energiamuodot :uusiutuva-polttoaine-kerroin]
-                          [:tulokset :kaytettavat-energiamuodot :fossiilinen-polttoaine-kerroin]
-                          [:tulokset :kaytettavat-energiamuodot :kaukojaahdytys-kerroin]}
           hidden-columns #{[:laatija-fullname]
                            [:tila-id]
                            [:korvaava-energiatodistus-id]
                            [:laatija-id]
                            [:perustiedot :yritys :nimi]}
-          expected-headers (columns->header-strings extra-columns)
           header-set (set headers)]
 
       ;; Verify that all expected headers from public-columns are present in the CSV
-      (t/is (set/subset? expected-headers header-set)
+      (t/is (set/subset? (columns->header-strings public-columns) header-set)
             "CSV headers should include all public-columns definitions")
 
       ;; Transform hidden-columns to header strings


### PR DESCRIPTION
Aika pitkälti olemassaolevaa totetusta mukaillen toteutettu uusi sisäinen endpoint julkisen puolen CSV-tiedostojen lataamiselle S3:een.

Aineisto.clj -tiedostossa tulee nyt hieman duplikaatti koodia ja ajattelin yhtenäistää toteutusta kunhan saan palautetta että olenhan tajunnut toiminnallisuuden oikein.

Testasin MinIO Consolen kautta ja näytti tulevan oikean kansion alle CSV:t