### PR TITLE
AE-2134 Set headers in the devserver proxy

### DIFF
--- a/etp-front/package.json
+++ b/etp-front/package.json
@@ -12,7 +12,7 @@
     "test": "npx --node-options=\"--experimental-vm-modules\" jest",
     "coverage": "npx --node-options=\"--experimental-vm-modules\" jest --coverage=true --coverageDirectory=coverage",
     "tdd": "npx --node-options=\"--experimental-vm-modules\" jest --watchAll",
-    "format": "prettier --write src modheaders.json",
+    "format": "prettier --write src modheaders.json webpack.config.js",
     "check-format": "prettier --check src",
     "build:docs": "jsdoc -r -c ./jsdoc/conf.json",
     "watch:docs": "nodemon --exec npm run build:docs --watch src"


### PR DESCRIPTION
As an alternative for using a browser extension, this allows setting the target user's email address into the ETP_DEV_FRONT_USER env variable and having the devserver proxy set authentication headers to match, based on content in modheaders.json.