### PR TITLE
feature/AE-1230 search fixes

### DIFF
--- a/etp-core/Justfile
+++ b/etp-core/Justfile
@@ -2,15 +2,16 @@
 _default:
   @just --list
 
-test:
-  cd ./etp-backend && \
+test:  
+  # every line is run in its own shell, so cwd-dependent stuff has to be made a one line with \ continuations
+  cd ./etp-backend; \
   clojure -M:dev:test
 
 clean:
-  cd ./docker && \
+  cd ./docker; \
   ./flyway.sh clean
 
 clean-migrate:
-  cd ./docker && \
-  ./flyway.sh clean && \
+  cd ./docker; \
+  ./flyway.sh clean; \
   ./flyway.sh migrate

--- a/etp-core/Justfile
+++ b/etp-core/Justfile
@@ -1,0 +1,16 @@
+# default recipe to display help information
+_default:
+  @just --list
+
+test:
+  cd ./etp-backend && \
+  clojure -M:dev:test
+
+clean:
+  cd ./docker && \
+  ./flyway.sh clean
+
+clean-migrate:
+  cd ./docker && \
+  ./flyway.sh clean && \
+  ./flyway.sh migrate

--- a/etp-core/README.md
+++ b/etp-core/README.md
@@ -175,3 +175,14 @@ Other environments
 Both projects contain script ```build-docker-image.sh``` which can be
 used to build the uberjars and related docker containers. The build containers
 can be executed by running ```docker run [etp-db or etp-backend]```.
+
+Justfile
+---
+There's a justfile in this directory. It makes it easier to run backend tests and clean+migrate the dev deb. Running `$ just` should list all the file's abilities if they've changed after writing this document.
+
+To use the file install [just](https://github.com/casey/just) from your package manager and use it as if it was make that knew what it could do.
+
+I interpret the readme in a way that recipes that don't call explicit sh features should work on windows too. I'm not certain if `$ just` just errors if run without an sh present, or if it defaults to pwsh if no sh found, and I can't test it myself. However, using just is just a convinience, and it's not a requirement so... hope it works in win too :D
+
+### TODO 
+Move just a directory higher and teach it to start the frontend npm jobs?

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search_fields.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus_search_fields.clj
@@ -117,7 +117,12 @@
      (per-nettoala-for-schema
        [:tulokset :lampokuormat]
        #(str % "-neliovuosikuorma")
-       energiatodistus-schema/Energiatodistus2018)}
+       energiatodistus-schema/Energiatodistus2018)
+
+     :tekniset-jarjestelmat
+     {:kaukojaahdytys ["energiatodistus.t$kaytettavat_energiamuodot$kaukojaahdytys + energiatodistus.t$tekniset_jarjestelmat$jaahdytys$kaukojaahdytys" common-schema/NonNegative]
+      :lampo ["( energiatodistus.lt$ilmanvaihto$tuloilma_lampotila + energiatodistus.t$tekniset_jarjestelmat$jaahdytys$lampo + energiatodistus.t$tekniset_jarjestelmat$kayttoveden_valmistus$lampo + energiatodistus.t$tekniset_jarjestelmat$tilojen_lammitys$lampo + energiatodistus.t$tekniset_jarjestelmat$tuloilman_lammitys$lampo + energiatodistus.t$uusiutuvat_omavaraisenergiat$aurinkolampo + energiatodistus.t$uusiutuvat_omavaraisenergiat$lampopumppu + energiatodistus. t$uusiutuvat_omavaraisenergiat$muulampo )" common-schema/NonNegative]
+      :sahko ["( energiatodistus.t$kaytettavat_energiamuodot$sahko + energiatodistus.t$tekniset_jarjestelmat$jaahdytys$sahko + energiatodistus.t$tekniset_jarjestelmat$kayttoveden_valmistus$sahko + energiatodistus.t$tekniset_jarjestelmat$tilojen_lammitys$sahko + energiatodistus.t$tekniset_jarjestelmat$tuloilman_lammitys$sahko)" common-schema/NonNegative]}}
     :toteutunut-ostoenergiankulutus
     {:ostettu-energia
      (per-nettoala-for-schema

--- a/etp-front/src/language/fi.json
+++ b/etp-front/src/language/fi.json
@@ -960,9 +960,9 @@
       "tekniset-jarjestelmat": {
         "header": "Rakennuksen teknisten järjestelmien energiankulutus",
         "label-context": "Tekniset järjestelmät",
-        "sahko": "Sähkö",
-        "lampo": "Lämpö",
-        "kaukojaahdytys": "Kauko\u00ADjäähdytys",
+        "sahko": "Sähkö yhteensä",
+        "lampo": "Lämpö yhteensä",
+        "kaukojaahdytys": "Kauko\u00ADjäähdytys yhteensä",
         "lammitysjarjestelma": "Lämmitys\u00ADjärjestelmä",
         "labels": {
           "tilojen-lammitys": "Tilojen lämmitys",

--- a/etp-front/src/language/sv.json
+++ b/etp-front/src/language/sv.json
@@ -935,9 +935,9 @@
         "header": "Energi som förbrukas av husets tekniska system",
         "label-context": "Tekniska system",
         "sahko": "El",
-        "lampo": "Värme",
-        "kaukojaahdytys": "Fjärrkyla",
-        "lammitysjarjestelma": "Uppvärmnings\u00ADsystemet",
+        "lampo": "Värme sammanlagt",
+        "kaukojaahdytys": "Fjärrkyla sammanlagt",
+        "lammitysjarjestelma": "Uppvärmnings\u00ADsystemet sammanlagt",
         "labels": {
           "tilojen-lammitys": "Uppvärm\u00ADning av utrymmen",
           "tuloilman-lammitys": "Uppvärm\u00ADning av tilluft",


### PR DESCRIPTION
Fixes the search-fields defined in the ticket. They didn't used to map to anything in the backend schema and didn't generate any sql in the search.

I'm not sure the aggregated fields are correct, but at least they're not `error` anymore.

Also the frontend's i18n facilities were funny so I'm not too confident on the changes to fi.json not causing any problems.

After I had to look up for the fifth time how to run tests, I also added Justfile to make it a bit easier to manage this project.