### PR TITLE
AE-2431: Varke -tekstimuutokset selosteet 

### DIFF
--- a/etp-front/src/pages/tietosuojaseloste/energiatodistusrekisteri/fi.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/energiatodistusrekisteri/fi.svelte
@@ -44,7 +44,7 @@
   </p>
 
   <p>
-    Aran lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
+    Varken lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
     laatijoita. Rekisterissä käsitellään henkilötietoja, jotka tarvitaan
     energiatodistusrekisterin ylläpitämiseksi.
   </p>
@@ -106,7 +106,7 @@
   </p>
 
   <p>
-    Ara on ulkoistanut energiatodistusrekisterin teknisen ylläpidon ja
+    Varke on ulkoistanut energiatodistusrekisterin teknisen ylläpidon ja
     kehittämisen IT-palveluntarjoajalle, jonka kanssa on solmittu
     tietosuoja-asetuksen mukainen sopimus henkilötietojen käsittelystä.
   </p>
@@ -127,7 +127,7 @@
 
   <p>
     Energiatodistusrekisterin sisältämien henkilötietojen säilytysajat
-    pohjautuvat Aran tiedonohjaussuunnitelmaan.
+    pohjautuvat Varken tiedonohjaussuunnitelmaan.
   </p>
 
   <H2 text="Rekisteröidyn oikeudet" />
@@ -173,16 +173,16 @@
 
   <H2 text="Rekisterinpitäjä" />
   <ul class="contact-info">
-    <li>Asumisen rahoitus- ja kehittämiskeskus (Ara)</li>
-    <li>PL 30, 15141 Lahti</li>
-    <li>Puhelin: 029 525 0800 (vaihde)</li>
-    <li>Sähköposti: kirjaamo.ara(at)ara.fi</li>
+    <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+    <li>PL 35, 00023 Valtioneuvosto</li>
+    <li>Puhelin: 0295 16001 (vaihde)</li>
+    <li>Sähköposti: varke.ym(at)gov.fi</li>
   </ul>
 
   <H2 text="Yhteyshenkilö" />
   <ul class="contact-info">
-    <li>Kirsi Unhonen, energia-asiantuntija</li>
-    <li>Asumisen rahoitus- ja kehittämiskeskus</li>
-    <li>etunimi.sukunimi(at)ara.fi</li>
+    <li>Kimmo Huovinen, apulaisjohtaja</li>
+    <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+    <li>etunimi.sukunimi(at)gov.fi</li>
   </ul>
 </div>

--- a/etp-front/src/pages/tietosuojaseloste/energiatodistusrekisteri/sv.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/energiatodistusrekisteri/sv.svelte
@@ -44,7 +44,7 @@
   </p>
 
   <p>
-    Aras lagstadgade uppgift är att övervaka energicertifikat och deras
+    Varkes lagstadgade uppgift är att övervaka energicertifikat och deras
     upprättare. I registret behandlas personuppgifter som behövs för att
     underhålla energicertifikatregistret.
   </p>
@@ -106,7 +106,7 @@
   </p>
 
   <p>
-    Ara har lagt ut det tekniska underhållet och utvecklandet av
+    Varke har lagt ut det tekniska underhållet och utvecklandet av
     Energicertifikatregistret på en IT-tjänsteleverantör med vilken det har
     ingåtts ett avtal om användning av personuppgifter enligt
     dataskyddsförordningen.
@@ -128,7 +128,7 @@
 
   <p>
     Lagringsperioderna för personuppgifter i Energicertifikatregistret grundar
-    sig i lagstiftning och Aras informationsstyrningsplan.
+    sig i lagstiftning och Varkes informationsstyrningsplan.
   </p>
 
   <H2 text="Den registrerades rättigheter" />
@@ -177,16 +177,16 @@
 
   <H2 text="Personuppgiftsansvarig" />
   <ul class="contact-info">
-    <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-    <li>PB 30, 15141 Lahtis</li>
-    <li>Telefon: 029 525 0800 (växel)</li>
-    <li>E-post: kirjaamo.ara(at)ara.fi</li>
+    <li>Centralen föt statligt stött bostadsbyggande (Varke)</li>
+    <li>PB 35, 00023 Statsrådet</li>
+    <li>Telefon: 0295 16001(växel)</li>
+    <li>E-post: kirjaamo.ara(at)varke.fi</li>
   </ul>
 
   <H2 text="Kontaktperson i ärenden som gäller registret" />
   <ul class="contact-info">
-    <li>Kirsi Unhonen, energiexpert</li>
-    <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-    <li>förnamn.efternamn(at)ara.fi</li>
+    <li>Kimmo Huovinen, biträdande direktör</li>
+    <li>Centralen föt statligt stött bostadsbyggande (Varke)</li>
+    <li>förnamn.efternamn(at)gov.fi</li>
   </ul>
 </div>

--- a/etp-front/src/pages/tietosuojaseloste/laatijarekisteri/fi.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/laatijarekisteri/fi.svelte
@@ -43,7 +43,7 @@
   </p>
 
   <p>
-    Aran lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
+    Varken lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
     laatijoita. Rekisterissä käsitellään henkilötietoja, jotka tarvitaan
     energiatodistusten laatijarekisterin ylläpitämiseksi. Osaa rekisterin
     tiedoista pidetään esillä julkisessa tietopalvelussa. Henkilötietoja
@@ -119,7 +119,7 @@
   </p>
 
   <p>
-    Aran verkkosivujen kautta on julkisesti haettavissa kaikkien
+    Varken verkkosivujen kautta on julkisesti haettavissa kaikkien
     rekisteröityneiden nimi, toiminta-alue ja laatijapätevyyden voimassaolo.
     Rekisteröidyt voivat itse määritellä myös osoitteen, puhelinnumeron,
     sähköpostiosoitteen ja verkkosivun julkisesti saataville.
@@ -132,7 +132,7 @@
   </p>
 
   <p>
-    Ara on ulkoistanut laatijarekisterin teknisen ylläpidon ja kehittämisen
+    Varke on ulkoistanut laatijarekisterin teknisen ylläpidon ja kehittämisen
     IT-palveluntarjoajalle, jonka kanssa on laadittu tietosuoja-asetuksen
     mukainen sopimus henkilötietojen käsittelystä.
   </p>
@@ -146,7 +146,7 @@
 
   <p>
     Energiatodistusten laatijarekisterin sisältämien henkilötietojen
-    säilytysajat pohjautuvat Aran tiedonohjaussuunnitelmaan.
+    säilytysajat pohjautuvat Varken tiedonohjaussuunnitelmaan.
   </p>
 
   <H2 text="Rekisteröidyn oikeudet" />
@@ -185,14 +185,14 @@
     </li>
     <li>
       laatijapätevyyden voimassaoloaika päättyy eikä pätevyyden toteaja ole
-      ilmoittanut pätevyyden uusimisesta Aralle;
+      ilmoittanut pätevyyden uusimisesta Varkelle;
     </li>
     <li>laatijalle on annettu todistusten laatimiskielto;</li>
     <li>
       laatijan osalta toiminnan harjoittamisen yleiset edellytykset eivät enää
       täyty;
     </li>
-    <li>Ara on saanut tiedon laatijan kuolemasta.</li>
+    <li>Varke on saanut tiedon laatijan kuolemasta.</li>
   </ol>
 
   <p>
@@ -226,17 +226,17 @@
   <H2 text="Rekisterinpitäjä" />
 
   <ul class="contact-info">
-    <li>Asumisen rahoitus- ja kehittämiskeskus (Ara)</li>
-    <li>PL 30, 15141 Lahti</li>
-    <li>Puhelin: 029 525 0800 (vaihde)</li>
-    <li>Sähköposti: kirjaamo.ara(at)ara.fi</li>
+    <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+    <li>PL 35, 0023 Valtioneuvosto</li>
+    <li>Puhelin: 0295 16001 (vaihde)</li>
+    <li>Sähköposti: varke.ym(at)gov.fi</li>
   </ul>
 
   <H2 text="Yhteyshenkilö" />
 
   <ul class="contact-info">
-    <li>Kirsi Unhonen, energia-asiantuntija</li>
-    <li>Asumisen rahoitus- ja kehittämiskeskus</li>
-    <li>etunimi.sukunimi(at)ara.fi</li>
+    <li>Kimmo Huovinen, apulaisjohtaja</li>
+    <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+    <li>etunimi.sukunimi(at)gov.fi</li>
   </ul>
 </div>

--- a/etp-front/src/pages/tietosuojaseloste/laatijarekisteri/sv.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/laatijarekisteri/sv.svelte
@@ -133,8 +133,8 @@
   </p>
 
   <p>
-    Varke har lagt ut energicertifikatregistrets tekniska underhåll och utveckling
-    åt en extern IT-tjänsteleverantör genom ett avtal enligt
+    Varke har lagt ut energicertifikatregistrets tekniska underhåll och
+    utveckling åt en extern IT-tjänsteleverantör genom ett avtal enligt
     dataskyddsförordningen angående behandlingen av personuppgifter.
   </p>
 
@@ -201,10 +201,7 @@
       om upprättaren inte längre har allmänna förutsättningar för att bedriva
       verksamhet,
     </li>
-    <li>
-      när Varke har erhållit
-      information om att upprättaren har avlidit.
-    </li>
+    <li>när Varke har erhållit information om att upprättaren har avlidit.</li>
   </ol>
 
   <p>

--- a/etp-front/src/pages/tietosuojaseloste/laatijarekisteri/sv.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/laatijarekisteri/sv.svelte
@@ -45,7 +45,7 @@
   </p>
 
   <p>
-    Aras lagstadgade uppgift är att övervaka energicertifikat och deras
+    Varkes lagstadgade uppgift är att övervaka energicertifikat och deras
     upprättare. I registret behandlas personuppgifter som behövs för att
     underhålla registret över upprättare av energicertifikat. En del av
     uppgifterna ska vara tillgängliga genom den offentliga informationstjänsten.
@@ -120,7 +120,7 @@
   </p>
 
   <p>
-    På Aras webbplats kan man offentligt söka alla registrerades namn,
+    På Varkes webbplats kan man offentligt söka alla registrerades namn,
     verksamhetsområden och giltighet för upprättarbehörighet. Registrerade kan
     även själv göra adress, telefonnummer, e-postadress och webbplats offentligt
     tillgängliga.
@@ -133,7 +133,7 @@
   </p>
 
   <p>
-    Ara har lagt ut energicertifikatregistrets tekniska underhåll och utveckling
+    Varke har lagt ut energicertifikatregistrets tekniska underhåll och utveckling
     åt en extern IT-tjänsteleverantör genom ett avtal enligt
     dataskyddsförordningen angående behandlingen av personuppgifter.
   </p>
@@ -147,7 +147,7 @@
 
   <p>
     Lagringsperioderna för personuppgifter i register för upprättare av
-    energicertifikat grundar sig i lagstiftning och Aras
+    energicertifikat grundar sig i lagstiftning och Varkes
     informationsstyrningsplan.
   </p>
 
@@ -202,7 +202,7 @@
       verksamhet,
     </li>
     <li>
-      när Finansierings- och utvecklingscentralen för boendet har erhållit
+      när Varke har erhållit
       information om att upprättaren har avlidit.
     </li>
   </ol>
@@ -240,17 +240,17 @@
   <H2 text="Personuppgiftsansvarig" />
 
   <ul class="contact-info">
-    <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-    <li>PB 30, 15141 Lahtis</li>
-    <li>Telefon: 029 525 0800 (växel)</li>
-    <li>E-post: kirjaamo.ara(at)ara.fi</li>
+    <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+    <li>PB 35, 00023 Statsrådet</li>
+    <li>Telefon: 0295 16001 (växel)</li>
+    <li>E-post: varke.ym(at)gov.fi</li>
   </ul>
 
   <H2 text="Kontaktperson i ärenden som gäller registret" />
 
   <ul class="contact-info">
-    <li>Kirsi Unhonen, energiexpert</li>
-    <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-    <li>förnamn.efternamn(at)ara.fi</li>
+    <li>Kimmo Huovinen, biträdande direktör</li>
+    <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+    <li>förnamn.efternamn(at)gov.fi</li>
   </ul>
 </div>

--- a/etp-front/src/pages/tietosuojaseloste/valvontatietorekisteri/fi.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/valvontatietorekisteri/fi.svelte
@@ -44,9 +44,9 @@
   </p>
 
   <p>
-    Aran lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
+    Varken lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
     laatijoita. Rekisterissä käsitellään henkilötietoja, jotka tarvitaan
-    energiatodistusten valvontatietorekisterin ylläpitämiseksi. Ara valvoo
+    energiatodistusten valvontatietorekisterin ylläpitämiseksi. Varke valvoo
     energiatodistusten käyttöä ja oikeellisuutta sekä laatijoiden toimintaa.
   </p>
 
@@ -115,7 +115,7 @@
 
   <p>
     Tietojärjestelmän tekninen ylläpito ja kehittäminen on ulkoistettu
-    IT-palveluntarjoajalle. Ara on tehnyt palveluntarjoajan kanssa
+    IT-palveluntarjoajalle. Varke on tehnyt palveluntarjoajan kanssa
     tietosuoja-asetuksen mukaisen sopimuksen henkilötietojen käsittelystä.
   </p>
 
@@ -136,7 +136,7 @@
 
   <p>
     Energiatodistusten valvontatietorekisterin sisältämien henkilötietojen
-    säilytysajat pohjautuvat Aran tiedonohjaussuunnitelmaan.
+    säilytysajat pohjautuvat Varken tiedonohjaussuunnitelmaan.
   </p>
 
   <H2 text="Rekisteröidyn oikeudet" />
@@ -192,17 +192,17 @@
   <H2 text="Rekisterinpitäjä" />
 
   <ul class="contact-info">
-    <li>Asumisen rahoitus- ja kehittämiskeskus (Ara)</li>
-    <li>PL 30, 15141 Lahti</li>
-    <li>Puhelin: 029 525 0800 (vaihde)</li>
-    <li>Sähköposti: kirjaamo.ara(at)ara.fi</li>
+    <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+    <li>PL 35, 00023 Valtioneuvosto</li>
+    <li>Puhelin: 0295 16001 (vaihde)</li>
+    <li>Sähköposti: varke.ym(at)gov.fi</li>
   </ul>
 
   <H2 text="Yhteyshenkilö" />
 
   <ul class="contact-info">
-    <li>Kirsi Unhonen, energia-asiantuntija</li>
-    <li>Asumisen rahoitus- ja kehittämiskeskus</li>
-    <li>etunimi.sukunimi(at)ara.fi</li>
+    <li>Kimmo Huovinen, apulaisjohtaja</li>
+    <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+    <li>etunimi.sukunimi(at)gov.fi</li>
   </ul>
 </div>

--- a/etp-front/src/pages/tietosuojaseloste/valvontatietorekisteri/sv.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/valvontatietorekisteri/sv.svelte
@@ -45,13 +45,13 @@
   </p>
 
   <p>
-    Aras lagstadgade uppgift är övervaka energicertifikat och deras upprättare.
+    Varkes lagstadgade uppgift är övervaka energicertifikat och deras upprättare.
     I registret behandlas personuppgifter som behövs för att underhålla
     registret för övervakningsuppgifter om energicertifikat.
   </p>
 
   <p>
-    Ara övervakar användningen och riktigheten av energicertifikaten samt deras
+    Varke övervakar användningen och riktigheten av energicertifikaten samt deras
     upprättarens verksamhet.
   </p>
 
@@ -121,7 +121,7 @@
   </p>
 
   <p>
-    Ara har lagt ut registrets tekniska underhåll och utveckling åt en extern
+    Varke har lagt ut registrets tekniska underhåll och utveckling åt en extern
     IT-tjänsteleverantör genom ett avtal enligt dataskyddsförordningen angående
     behandlingen av personuppgifter.
   </p>
@@ -144,7 +144,7 @@
 
   <p>
     Lagringsperioderna för personuppgifter i registret för övervakningsuppgifter
-    om energicertifikat grundar sig i Aras informationsstyrningsplan.
+    om energicertifikat grundar sig i Varkes informationsstyrningsplan.
   </p>
 
   <H2 text="Den registrerades rättigheter" />
@@ -203,17 +203,17 @@
   <H2 text="Personuppgiftsansvarig" />
 
   <ul class="contact-info">
-    <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-    <li>PB 30, 15141 Lahtis</li>
-    <li>Tfn (växel): 029 525 0800</li>
-    <li>E-post: E-post adress: kirjaamo.ara(at)ara.fi</li>
+    <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+    <li>PB 35, 00023 Statsrådet</li>
+    <li>Tfn (växel): 0295 16001</li>
+    <li>E-post: E-post adress: varke.ym(at)gov.fi</li>
   </ul>
 
   <H2 text="Kontaktperson i ärenden som gäller registret" />
 
   <ul class="contact-info">
-    <li>Kirsi Unhonen, energiexpert</li>
-    <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-    <li>fornamn.efternamn(at)ara.fi</li>
+    <li>Kimmo Huovinen, biträdande direktör</li>
+    <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+    <li>fornamn.efternamn(at)gov.fi</li>
   </ul>
 </div>

--- a/etp-front/src/pages/tietosuojaseloste/valvontatietorekisteri/sv.svelte
+++ b/etp-front/src/pages/tietosuojaseloste/valvontatietorekisteri/sv.svelte
@@ -45,14 +45,14 @@
   </p>
 
   <p>
-    Varkes lagstadgade uppgift är övervaka energicertifikat och deras upprättare.
-    I registret behandlas personuppgifter som behövs för att underhålla
-    registret för övervakningsuppgifter om energicertifikat.
+    Varkes lagstadgade uppgift är övervaka energicertifikat och deras
+    upprättare. I registret behandlas personuppgifter som behövs för att
+    underhålla registret för övervakningsuppgifter om energicertifikat.
   </p>
 
   <p>
-    Varke övervakar användningen och riktigheten av energicertifikaten samt deras
-    upprättarens verksamhet.
+    Varke övervakar användningen och riktigheten av energicertifikaten samt
+    deras upprättarens verksamhet.
   </p>
 
   <H2 text="Vilka personuppgifter behandlas?" />

--- a/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-fi.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-fi.svelte
@@ -127,8 +127,8 @@
     <p>Soveltuu esimerkiksi tutkimuskäyttöön.</p>
     <H2>KÄYTTÖEHDOT</H2>
     <p>
-      Aineistopalvelun käyttäminen edellyttää, että Ara on myöntänyt käyttäjälle
-      tietoluvan. Lisäksi Ara ja käyttäjä solmivat erillisen sopimuksen
+      Aineistopalvelun käyttäminen edellyttää, että Varke on myöntänyt käyttäjälle
+      tietoluvan. Lisäksi Varke ja käyttäjä solmivat erillisen sopimuksen
       Aineistopalvelun käytöstä.
     </p>
     <p>
@@ -148,7 +148,7 @@
       Hinnastomme löydät
       <Link
         href="https://www.ara.fi/fi/tietoa-meista/yhteystiedot/maksullisten-palvelujen-hinnat"
-        >Aran sivuilta</Link>
+        >Varken sivuilta</Link>
       .
     </p>
     <H2>AINEISTOPALVELUUN LIITTYMINEN</H2>
@@ -162,8 +162,8 @@
         >.
       </li>
       <li>
-        Lähetä hakemus sähköpostitse Aran kirjaamoon (<Link
-          href="mailto:kirjaamo.ara@ara.fi">kirjaamo.ara@ara.fi</Link
+        Lähetä hakemus sähköpostitse Varken kirjaamoon (<Link
+          href="mailto:varke.ym@gov.fi">varke.ym@gov.fi</Link
         >). Jos hakemus sisältää salassa pidettävää tietoa, lähetä hakemus <Link
           href="https://turvaviesti.ara.fi/">turvapostilla</Link
         >.
@@ -193,7 +193,7 @@
     <H2>TOIMINTA HÄIRIÖTILANTEISSA</H2>
     <p>
       Aineistopalveluun liittyvissä häiriötilanteissa ota yhteyttä sähköpostitse
-      <Link href="mailto:energiatodistus@ara.fi">energiatodistus@ara.fi</Link>.
+      <Link href="mailto:energiatodistus.varke@gov.fi">energiatodistus.varke@gov.fi</Link>.
     </p>
   </div>
 </Container>

--- a/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-fi.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-fi.svelte
@@ -127,9 +127,9 @@
     <p>Soveltuu esimerkiksi tutkimuskäyttöön.</p>
     <H2>KÄYTTÖEHDOT</H2>
     <p>
-      Aineistopalvelun käyttäminen edellyttää, että Varke on myöntänyt käyttäjälle
-      tietoluvan. Lisäksi Varke ja käyttäjä solmivat erillisen sopimuksen
-      Aineistopalvelun käytöstä.
+      Aineistopalvelun käyttäminen edellyttää, että Varke on myöntänyt
+      käyttäjälle tietoluvan. Lisäksi Varke ja käyttäjä solmivat erillisen
+      sopimuksen Aineistopalvelun käytöstä.
     </p>
     <p>
       Aineistopalveluun liittymisestä perimme hinnastomme mukaisen
@@ -193,7 +193,9 @@
     <H2>TOIMINTA HÄIRIÖTILANTEISSA</H2>
     <p>
       Aineistopalveluun liittyvissä häiriötilanteissa ota yhteyttä sähköpostitse
-      <Link href="mailto:energiatodistus.varke@gov.fi">energiatodistus.varke@gov.fi</Link>.
+      <Link href="mailto:energiatodistus.varke@gov.fi"
+        >energiatodistus.varke@gov.fi</Link
+      >.
     </p>
   </div>
 </Container>

--- a/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-fi.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-fi.svelte
@@ -147,7 +147,7 @@
     <p>
       Hinnastomme löydät
       <Link
-        href="https://www.ara.fi/fi/tietoa-meista/yhteystiedot/maksullisten-palvelujen-hinnat"
+        href="https://www.varke.fi/fi/tietoa-meista/yhteystiedot/maksullisten-palvelujen-hinnat"
         >Varken sivuilta</Link>
       .
     </p>
@@ -165,7 +165,7 @@
         Lähetä hakemus sähköpostitse Varken kirjaamoon (<Link
           href="mailto:varke.ym@gov.fi">varke.ym@gov.fi</Link
         >). Jos hakemus sisältää salassa pidettävää tietoa, lähetä hakemus <Link
-          href="https://turvaviesti.ara.fi/">turvapostilla</Link
+          href="https://turvaviesti.varke.fi/">turvapostilla</Link
         >.
       </li>
       <li>

--- a/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-sv.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-sv.svelte
@@ -167,7 +167,8 @@
         Skicka ansökan per e-post till Varkes registratorskontor (<Link
           href="mailto:varke.ym@gov.fi">varke.ym@gov.fi</Link
         >). Om ansökan innehåller sekretessbelagd information ska du skicka
-        ansökan som <Link href="https://turvaviesti.varke.fi/">säker e-post</Link
+        ansökan som <Link href="https://turvaviesti.varke.fi/"
+          >säker e-post</Link
         >.
       </li>
       <li>
@@ -196,7 +197,9 @@
     <p>
       Vid störningar i materialtjänsten ska du kontakta oss per e-post på
       adressen
-      <Link href="mailto:energiatodistus.varke@gov.fi">energiatodistus.varke@gov.fi</Link>.
+      <Link href="mailto:energiatodistus.varke@gov.fi"
+        >energiatodistus.varke@gov.fi</Link
+      >.
     </p>
   </div>
 </Container>

--- a/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-sv.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-sv.svelte
@@ -128,8 +128,8 @@
     <p>Lämpar sig till exempel för forskningsändamål.</p>
     <H2>ANVÄNDNINGSVILLKOR</H2>
     <p>
-      Användningen av datatjänsten förutsätter att ARA har beviljat användaren
-      datatillstånd. Dessutom ingår Ara och användaren ett separat avtal om
+      Användningen av datatjänsten förutsätter att Varke har beviljat användaren
+      datatillstånd. Dessutom ingår Varke och användaren ett separat avtal om
       användningen av Materialtjänsten.
     </p>
     <p>
@@ -150,7 +150,7 @@
       Vår prislista finns på
       <Link
         href="https://www.ara.fi/sv/om-oss/kontaktuppgifter/priser-avgiftsbelagda-tjanster"
-        >Aras webbplats</Link
+        >Varkes webbplats</Link
       >.
     </p>
     <H2>ANSLUTNING TILL MATERIALTJÄNSTEN</H2>
@@ -164,8 +164,8 @@
         </Link>.
       </li>
       <li>
-        Skicka ansökan per e-post till Aras registratorskontor (<Link
-          href="mailto:kirjaamo.ara@ara.fi">kirjaamo.ara@ara.fi</Link
+        Skicka ansökan per e-post till Varkes registratorskontor (<Link
+          href="mailto:varke.ym@gov.fi">varke.ym@gov.fi</Link
         >). Om ansökan innehåller sekretessbelagd information ska du skicka
         ansökan som <Link href="https://turvaviesti.ara.fi/">säker e-post</Link
         >.
@@ -196,7 +196,7 @@
     <p>
       Vid störningar i materialtjänsten ska du kontakta oss per e-post på
       adressen
-      <Link href="mailto:energiatodistus@ara.fi">energiatodistus@ara.fi</Link>.
+      <Link href="mailto:energiatodistus.varke@gov.fi">energiatodistus.varke@gov.fi</Link>.
     </p>
   </div>
 </Container>

--- a/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-sv.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-aineistopalvelu-sv.svelte
@@ -149,7 +149,7 @@
     <p>
       Vår prislista finns på
       <Link
-        href="https://www.ara.fi/sv/om-oss/kontaktuppgifter/priser-avgiftsbelagda-tjanster"
+        href="https://www.varke.fi/sv/om-oss/kontaktuppgifter/priser-avgiftsbelagda-tjanster"
         >Varkes webbplats</Link
       >.
     </p>
@@ -167,7 +167,7 @@
         Skicka ansökan per e-post till Varkes registratorskontor (<Link
           href="mailto:varke.ym@gov.fi">varke.ym@gov.fi</Link
         >). Om ansökan innehåller sekretessbelagd information ska du skicka
-        ansökan som <Link href="https://turvaviesti.ara.fi/">säker e-post</Link
+        ansökan som <Link href="https://turvaviesti.varke.fi/">säker e-post</Link
         >.
       </li>
       <li>

--- a/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-fi.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-fi.svelte
@@ -61,8 +61,8 @@
   <div class="px-4 lg:px-8 xl:px-16 pt-8 pb-4 mx-auto">
     <H2>KÄYTTÖEHDOT</H2>
     <p>
-      Energiatodistusrekisterin rajapintapalvelun käyttö edellyttää Aran
-      myöntämää tietolupaa. Sen lisäksi Ara ja palvelun käyttäjä solmivat
+      Energiatodistusrekisterin rajapintapalvelun käyttö edellyttää Varken
+      myöntämää tietolupaa. Sen lisäksi Varke ja palvelun käyttäjä solmivat
       erillisen sopimuksen. Energiatodistustiedot sisältävät henkilötietoa,
       joten palveluun voivat liittyä vain ne käyttäjät, joilla on oikeus
       käsitellä henkilötietoa.
@@ -80,7 +80,7 @@
       Hinnastomme löydät
       <Link
         href="https://www.ara.fi/fi/tietoa-meista/yhteystiedot/maksullisten-palvelujen-hinnat"
-        >Aran sivuilta</Link
+        >Varken sivuilta</Link
       >.
     </p>
 
@@ -111,7 +111,7 @@
       <li>
         Täytä liityntäkatalogista löytyvä <Link
           href="https://liityntakatalogi.suomi.fi/dataset/energiatodistusrekisteri-ara-svc"
-          >hakemus</Link> ja odota Aran hyväksyntää.
+          >hakemus</Link> ja odota Varken hyväksyntää.
       </li>
       <li>
         Energiatodistusrekisterin rajapintapalvelu on käytettävissäsi. <Link

--- a/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-fi.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-fi.svelte
@@ -79,7 +79,7 @@
     <p>
       Hinnastomme löydät
       <Link
-        href="https://www.ara.fi/fi/tietoa-meista/yhteystiedot/maksullisten-palvelujen-hinnat"
+        href="https://www.varke.fi/fi/tietoa-meista/yhteystiedot/maksullisten-palvelujen-hinnat"
         >Varken sivuilta</Link
       >.
     </p>

--- a/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-sv.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-sv.svelte
@@ -85,7 +85,7 @@
     <p>
       Vår prislista finns på
       <Link
-        href="https://www.ara.fi/sv/om-oss/kontaktuppgifter/priser-avgiftsbelagda-tjanster"
+        href="https://www.varke.fi/sv/om-oss/kontaktuppgifter/priser-avgiftsbelagda-tjanster"
         >Varkes webbplats
       </Link>
       .

--- a/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-sv.svelte
+++ b/etp-public/src/pages/energiatodistusrekisterin-rajapintapalvelu-sv.svelte
@@ -64,7 +64,7 @@
     <H2>ANVÄNDNINGSVILLKOR</H2>
     <p>
       Användningen av energicertifikatregistrets gränssnittstjänst förutsätter
-      ett datatillstånd beviljat av Ara. Dessutom ingår Ara och tjänstens
+      ett datatillstånd beviljat av Varke. Dessutom ingår Varke och tjänstens
       användare ett separat avtal. Uppgifterna om energicertifikat innehåller
       personuppgifter, så endast de användare som har rätt att behandla
       personuppgifter kan ansluta sig till tjänsten.
@@ -86,7 +86,7 @@
       Vår prislista finns på
       <Link
         href="https://www.ara.fi/sv/om-oss/kontaktuppgifter/priser-avgiftsbelagda-tjanster"
-        >Aras webbplats
+        >Varkes webbplats
       </Link>
       .
     </p>
@@ -122,7 +122,7 @@
         <Link
           href="https://liityntakatalogi.suomi.fi/dataset/energiatodistusrekisteri-ara-svc"
           >ansökan</Link>
-        som finns i API-katalogen och vänta på Aras godkännande.
+        som finns i API-katalogen och vänta på Varkes godkännande.
       </li>
       <li>
         Du har tillgång till energicertifikatregistrets gränssnittstjänst

--- a/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-fi.svelte
+++ b/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-fi.svelte
@@ -35,8 +35,8 @@
   <div bind:this={component}>
     <InfoBlock {title} showIcon={false}>
       <p>
-        Organisaatiot voivat saada Valtion tukeman asuntorakentamisen keskuksen (Varke)
-        ylläpitämästä energiatodistusrekisteristä energiatodistustietoa
+        Organisaatiot voivat saada Valtion tukeman asuntorakentamisen keskuksen
+        (Varke) ylläpitämästä energiatodistusrekisteristä energiatodistustietoa
         kolmella eri tavalla.
       </p>
       <ol class="ml-6">
@@ -81,7 +81,8 @@
     <p>
       Varke noudattaa kaikessa toiminnassaan huolellisuutta ja varmistaa, että
       tietosuoja ja tietoturvallisuus toteutuvat. Henkilötietojen käsittely
-      perustuu pääsääntöisesti Varken lakisääteisten velvoitteiden noudattamiseen.
+      perustuu pääsääntöisesti Varken lakisääteisten velvoitteiden
+      noudattamiseen.
       <Link
         href="https://www.varke.fi/fi/tietoa-meista/tietosuoja-ja-tietojen-kasittely">
         Lue lisää henkilötietojen käsittelystä (varke.fi)</Link>

--- a/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-fi.svelte
+++ b/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-fi.svelte
@@ -83,7 +83,7 @@
       tietosuoja ja tietoturvallisuus toteutuvat. Henkilötietojen käsittely
       perustuu pääsääntöisesti Varken lakisääteisten velvoitteiden noudattamiseen.
       <Link
-        href="https://www.ara.fi/fi/tietoa-meista/tietosuoja-ja-tietojen-kasittely">
+        href="https://www.varke.fi/fi/tietoa-meista/tietosuoja-ja-tietojen-kasittely">
         Lue lisää henkilötietojen käsittelystä (varke.fi)</Link>
 
       Pidämme rekisteriä rajapintaan liitetyistä aineistoasiakkaista.

--- a/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-fi.svelte
+++ b/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-fi.svelte
@@ -35,8 +35,8 @@
   <div bind:this={component}>
     <InfoBlock {title} showIcon={false}>
       <p>
-        Organisaatiot voivat saada Asumisen rahoitus- ja kehittämiskeskuksen
-        (Ara) ylläpitämästä energiatodistusrekisteristä energiatodistustietoa
+        Organisaatiot voivat saada Valtion tukeman asuntorakentamisen keskuksen (Varke)
+        ylläpitämästä energiatodistusrekisteristä energiatodistustietoa
         kolmella eri tavalla.
       </p>
       <ol class="ml-6">
@@ -55,8 +55,8 @@
           Käsittelemme ilman rajapintaa toteutettavat tietopyynnöt
           tapauskohtaisesti ja veloitamme niistä tuntihinnastomme mukaisesti. <br />
           Lisätietoja:
-          <Link href="mailto:energiatodistus@ara.fi"
-            >energiatodistus@ara.fi</Link>
+          <Link href="mailto:energiatodistus.varke@gov.fi"
+            >energiatodistus.varke@gov.fi</Link>
         </li>
       </ol>
     </InfoBlock>
@@ -68,7 +68,7 @@
     <H2>Rajapintoihin liittyminen ja tietosuoja</H2>
     <p>
       Palveluihin liittyminen on maksullista ja niiden käyttäminen edellyttää
-      Aran myöntämää tietolupaa. Lisäksi Ara ja käyttäjä solmivat erillisen
+      Varken myöntämää tietolupaa. Lisäksi Varke ja käyttäjä solmivat erillisen
       sopimuksen palvelun käytöstä.
     </p>
     <p>
@@ -79,12 +79,12 @@
       saada käyttöön myös niin, että henkilötiedot on poistettu.
     </p>
     <p>
-      Ara noudattaa kaikessa toiminnassaan huolellisuutta ja varmistaa, että
+      Varke noudattaa kaikessa toiminnassaan huolellisuutta ja varmistaa, että
       tietosuoja ja tietoturvallisuus toteutuvat. Henkilötietojen käsittely
-      perustuu pääsääntöisesti Aran lakisääteisten velvoitteiden noudattamiseen.
+      perustuu pääsääntöisesti Varken lakisääteisten velvoitteiden noudattamiseen.
       <Link
         href="https://www.ara.fi/fi/tietoa-meista/tietosuoja-ja-tietojen-kasittely">
-        Lue lisää henkilötietojen käsittelystä (ara.fi)</Link>
+        Lue lisää henkilötietojen käsittelystä (varke.fi)</Link>
 
       Pidämme rekisteriä rajapintaan liitetyistä aineistoasiakkaista.
       Tietosuojaselosteet ovat sivulla

--- a/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-sv.svelte
+++ b/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-sv.svelte
@@ -36,8 +36,8 @@
     <InfoBlock {title} showIcon={false}>
       <p>
         Organisationerna kan få uppgifter om energicertifikat på tre olika sätt
-        från det energicertifikatregister som Finansierings- och
-        utvecklingscentralen för boendet (Ara) upprätthåller.
+        från det energicertifikatregister som Centralen för statligt stött bostadsbyggande
+        (Varke) upprätthåller.
       </p>
       <ol class="ml-6">
         <li>
@@ -56,8 +56,8 @@
           Vi behandlar begäran om information som genomförs utan gränssnitt från
           fall till fall och debiterar för dem enligt vår timprislista.
           <br />
-          Mer information: <Link href="mailto:energiatodistus@ara.fi"
-            >energiatodistus@ara.fi</Link>
+          Mer information: <Link href="mailto:energiatodistus.varke@gov.fi"
+            >energiatodistus.varke@gov.fi</Link>
         </li>
       </ol>
     </InfoBlock>
@@ -69,7 +69,7 @@
     <H2>Anslutning till gränssnitt och dataskydd</H2>
     <p>
       Det är avgiftsbelagt att ansluta sig till tjänsterna och användningen av
-      dem förutsätter ett datatillstånd beviljat av Ara. Dessutom ingår Ara och
+      dem förutsätter ett datatillstånd beviljat av Varke. Dessutom ingår Varke och
       användaren ett separat avtal om användningen av tjänsten.
     </p>
     <p>
@@ -81,11 +81,11 @@
       har raderats.
     </p>
     <p>
-      Ara är noggrann inom all sin verksamhet och säkerställer att dataskydd och
+      Varke är noggrann inom all sin verksamhet och säkerställer att dataskydd och
       informationssäkerhet uppfylls. Behandling av personuppgifter följer i
-      huvudregel Aras lagstadgade skyldigheter. <Link
+      huvudregel Varkes lagstadgade skyldigheter. <Link
         href="https://www.ara.fi/sv/om-oss/dataskydd-och-behandling-av-uppgifter">
-        Läs mer om behandlingen av personuppgifter på (ara.fi)</Link
+        Läs mer om behandlingen av personuppgifter på (varke.fi)</Link
       >. Vi för ett register över de materialkunder som anslutits till
       gränssnittet. Dataskyddsbeskrivningarna finns på sidan
       <Link href="/tietoa-sivustosta">Information om webbplatsen</Link>.

--- a/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-sv.svelte
+++ b/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-sv.svelte
@@ -84,7 +84,7 @@
       Varke är noggrann inom all sin verksamhet och säkerställer att dataskydd och
       informationssäkerhet uppfylls. Behandling av personuppgifter följer i
       huvudregel Varkes lagstadgade skyldigheter. <Link
-        href="https://www.ara.fi/sv/om-oss/dataskydd-och-behandling-av-uppgifter">
+        href="https://www.varke.fi/sv/om-oss/dataskydd-och-behandling-av-uppgifter">
         Läs mer om behandlingen av personuppgifter på (varke.fi)</Link
       >. Vi för ett register över de materialkunder som anslutits till
       gränssnittet. Dataskyddsbeskrivningarna finns på sidan

--- a/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-sv.svelte
+++ b/etp-public/src/pages/tietojenluovutus-ja-rajapinnat-sv.svelte
@@ -36,8 +36,8 @@
     <InfoBlock {title} showIcon={false}>
       <p>
         Organisationerna kan få uppgifter om energicertifikat på tre olika sätt
-        från det energicertifikatregister som Centralen för statligt stött bostadsbyggande
-        (Varke) upprätthåller.
+        från det energicertifikatregister som Centralen för statligt stött
+        bostadsbyggande (Varke) upprätthåller.
       </p>
       <ol class="ml-6">
         <li>
@@ -69,8 +69,8 @@
     <H2>Anslutning till gränssnitt och dataskydd</H2>
     <p>
       Det är avgiftsbelagt att ansluta sig till tjänsterna och användningen av
-      dem förutsätter ett datatillstånd beviljat av Varke. Dessutom ingår Varke och
-      användaren ett separat avtal om användningen av tjänsten.
+      dem förutsätter ett datatillstånd beviljat av Varke. Dessutom ingår Varke
+      och användaren ett separat avtal om användningen av tjänsten.
     </p>
     <p>
       Adressuppgifter och permanenta byggnadsbeteckningar för energicertifikat
@@ -81,8 +81,8 @@
       har raderats.
     </p>
     <p>
-      Varke är noggrann inom all sin verksamhet och säkerställer att dataskydd och
-      informationssäkerhet uppfylls. Behandling av personuppgifter följer i
+      Varke är noggrann inom all sin verksamhet och säkerställer att dataskydd
+      och informationssäkerhet uppfylls. Behandling av personuppgifter följer i
       huvudregel Varkes lagstadgade skyldigheter. <Link
         href="https://www.varke.fi/sv/om-oss/dataskydd-och-behandling-av-uppgifter">
         Läs mer om behandlingen av personuppgifter på (varke.fi)</Link

--- a/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-fi.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-fi.svelte
@@ -55,12 +55,13 @@
       <H3>Henkilötietojen käyttötarkoitus ja käsittelyperuste</H3>
 
       <p>
-        Henkilötietojen käsittely perustuu Varken ja tietoluvan saajan (asiakkaan)
-        väliseen sopimukseen Aineistopalvelun käytöstä. Rekisterissä käsitellään
-        asiakkaan teknisen yhteyshenkilön henkilötietoja rajapintayhteyden
-        muodostamiseksi asiakkaan tietoverkkoon, ja ongelmatilanteiden
-        ratkaisemiseen. Lisäksi tietoja käytetään käyttövaltuuksien
-        hallinnointiin ja seurantaan sekä lokitietojen keräämiseen.
+        Henkilötietojen käsittely perustuu Varken ja tietoluvan saajan
+        (asiakkaan) väliseen sopimukseen Aineistopalvelun käytöstä. Rekisterissä
+        käsitellään asiakkaan teknisen yhteyshenkilön henkilötietoja
+        rajapintayhteyden muodostamiseksi asiakkaan tietoverkkoon, ja
+        ongelmatilanteiden ratkaisemiseen. Lisäksi tietoja käytetään
+        käyttövaltuuksien hallinnointiin ja seurantaan sekä lokitietojen
+        keräämiseen.
       </p>
 
       <H3>Mitä henkilötietoja käsitellään?</H3>

--- a/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-fi.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-fi.svelte
@@ -55,7 +55,7 @@
       <H3>Henkilötietojen käyttötarkoitus ja käsittelyperuste</H3>
 
       <p>
-        Henkilötietojen käsittely perustuu Aran ja tietoluvan saajan (asiakkaan)
+        Henkilötietojen käsittely perustuu Varken ja tietoluvan saajan (asiakkaan)
         väliseen sopimukseen Aineistopalvelun käytöstä. Rekisterissä käsitellään
         asiakkaan teknisen yhteyshenkilön henkilötietoja rajapintayhteyden
         muodostamiseksi asiakkaan tietoverkkoon, ja ongelmatilanteiden
@@ -96,7 +96,7 @@
       </p>
 
       <p>
-        Ara on ulkoistanut energiatodistusrekisterin ja siihen liittyvän
+        Varke on ulkoistanut energiatodistusrekisterin ja siihen liittyvän
         Aineistopalvelun teknisen ylläpidon ja kehittämisen
         IT-palveluntarjoajalle, jonka kanssa on solmittu tietosuoja-asetuksen
         mukainen sopimus henkilötietojen käsittelystä.
@@ -110,7 +110,7 @@
       <H3>Tietojen säilytysaika</H3>
 
       <p>
-        Henkilötietoja säilytetään Aran ja asiakkaan sopimuksen voimassaolon
+        Henkilötietoja säilytetään Varken ja asiakkaan sopimuksen voimassaolon
         ajan. Teknisen yhteyshenkilön vaihtuessa kesken sopimuskauden uusi
         tekninen yhteyshenkilö lisätään rekisteriin ja edeltäjän tiedot
         poistetaan rekisteristä.
@@ -165,17 +165,17 @@
       <H3>Rekisterinpitäjä</H3>
 
       <ul class="contact-info">
-        <li>Asumisen rahoitus- ja kehittämiskeskus (Ara)</li>
-        <li>PL 30, 15141 Lahti</li>
-        <li>Puhelin: 029 525 0800 (vaihde)</li>
-        <li>Sähköposti: kirjaamo.ara(at)ara.fi</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>PL 35, 00023 Valtioneuvosto</li>
+        <li>Puhelin: 0295 16001 (vaihde)</li>
+        <li>Sähköposti: varke.ym(at)gov.fi</li>
       </ul>
 
       <H3>Yhteyshenkilö</H3>
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energia-asiantuntija</li>
-        <li>Asumisen rahoitus- ja kehittämiskeskus</li>
-        <li>etunimi.sukunimi(at)ara.fi</li>
+        <li>Kimmo Huovinen, apulaisjohtaja</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>etunimi.sukunimi(at)gov.fi</li>
       </ul>
     </div>
   </div>

--- a/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-sv.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-sv.svelte
@@ -55,9 +55,9 @@
       <H3>Syftet med och grunden för behandlingen av personuppgifter</H3>
 
       <p>
-        Behandlingen av personuppgifter grundar sig på ett avtal mellan Varke och
-        datatillståndshavaren (kunden) om användningen av Materialtjänsten. I
-        registret behandlas personuppgifterna för kundens tekniska
+        Behandlingen av personuppgifter grundar sig på ett avtal mellan Varke
+        och datatillståndshavaren (kunden) om användningen av Materialtjänsten.
+        I registret behandlas personuppgifterna för kundens tekniska
         kontaktperson. Uppgifterna används för att skapa en
         gränssnittsförbindelse till kundens datanät samt för att lösa
         problemsituationer. Dessutom används uppgifterna för att administrera

--- a/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-sv.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-aineistopalvelun-kayttajarekisteri-sv.svelte
@@ -55,7 +55,7 @@
       <H3>Syftet med och grunden för behandlingen av personuppgifter</H3>
 
       <p>
-        Behandlingen av personuppgifter grundar sig på ett avtal mellan Ara och
+        Behandlingen av personuppgifter grundar sig på ett avtal mellan Varke och
         datatillståndshavaren (kunden) om användningen av Materialtjänsten. I
         registret behandlas personuppgifterna för kundens tekniska
         kontaktperson. Uppgifterna används för att skapa en
@@ -99,7 +99,7 @@
       </p>
 
       <p>
-        Ara har lagt ut energicertifikatregistret och det tillhörande tekniska
+        Varke har lagt ut energicertifikatregistret och det tillhörande tekniska
         underhållet och utvecklingen av Materialtjänsten åt en extern
         IT-tjänsteleverantör genom ett avtal enligt dataskyddsförordningen
         angående behandlingen av personuppgifter.
@@ -113,7 +113,7 @@
       <H3>Förvaringstid för personuppgifter</H3>
 
       <p>
-        Personuppgifterna förvaras under giltighetstiden för Aras och kundens
+        Personuppgifterna förvaras under giltighetstiden för Varkes och kundens
         avtal. Om den tekniska kontaktpersonen ändrar under avtalsperioden läggs
         den nya tekniska kontaktpersonen till i registret och föregångarens
         uppgifter raderas ur registret.
@@ -168,17 +168,17 @@
       <H3>Personuppgiftsansvarig</H3>
 
       <ul class="contact-info">
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>PB 30, 15141 Lahtis</li>
-        <li>Telefon: 029 525 0800 (växel)</li>
-        <li>E-post: kirjaamo.ara(at)ara.fi</li>
+        <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+        <li>PB 35, 00023 Statsrådet</li>
+        <li>Telefon: 0295 16001 (växel)</li>
+        <li>E-post: varke.ym(at)gov.fi</li>
       </ul>
 
       <H3>Kontaktperson i ärenden som gäller registret</H3>
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energiexpert</li>
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>förnamn.efternamn(at)ara.fi</li>
+        <li>Kimmo Huovinen, biträdande direktör</li>
+        <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+        <li>förnamn.efternamn(at)varke.fi</li>
       </ul>
     </div>
   </div>

--- a/etp-public/src/pages/tietosuojaseloste-energiatodistusrekisteri-fi.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-energiatodistusrekisteri-fi.svelte
@@ -61,7 +61,7 @@
       </p>
 
       <p>
-        Aran lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
+        Varken lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
         laatijoita. Rekisterissä käsitellään henkilötietoja, jotka tarvitaan
         energiatodistusrekisterin ylläpitämiseksi.
       </p>
@@ -135,7 +135,7 @@
       </p>
 
       <p>
-        Ara on ulkoistanut energiatodistusrekisterin teknisen ylläpidon ja
+        Varke on ulkoistanut energiatodistusrekisterin teknisen ylläpidon ja
         kehittämisen IT-palveluntarjoajalle, jonka kanssa on solmittu
         tietosuoja-asetuksen mukainen sopimus henkilötietojen käsittelystä.
       </p>
@@ -161,7 +161,7 @@
 
       <p>
         Energiatodistusrekisterin sisältämien henkilötietojen säilytysajat
-        pohjautuvat Aran tiedonohjaussuunnitelmaan.
+        pohjautuvat Varken tiedonohjaussuunnitelmaan.
       </p>
 
       <H3>Rekisteröidyn oikeudet</H3>
@@ -206,17 +206,17 @@
 
       <H3>Rekisterinpitäjä</H3>
       <ul class="contact-info">
-        <li>Asumisen rahoitus- ja kehittämiskeskus (Ara)</li>
-        <li>PL 30, 15141 Lahti</li>
-        <li>Puhelin: 029 525 0800 (vaihde)</li>
-        <li>Sähköposti: kirjaamo.ara(at)ara.fi</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>PL 35, 00023 Valtioneuvosto</li>
+        <li>Puhelin: 0295 16001 (vaihde)</li>
+        <li>Sähköposti: varke.ym(at)gov.fi</li>
       </ul>
 
       <H3>Yhteyshenkilö</H3>
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energia-asiantuntija</li>
-        <li>Asumisen rahoitus- ja kehittämiskeskus</li>
-        <li>etunimi.sukunimi(at)ara.fi</li>
+        <li>Kimmo Huovinen, apulaisjohtaja</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>etunimi.sukunimi(at)gov.fi</li>
       </ul>
     </div>
   </div>

--- a/etp-public/src/pages/tietosuojaseloste-energiatodistusrekisteri-sv.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-energiatodistusrekisteri-sv.svelte
@@ -60,7 +60,7 @@
       </p>
 
       <p>
-        Aras lagstadgade uppgift är att övervaka energicertifikat och deras
+        Varkes lagstadgade uppgift är att övervaka energicertifikat och deras
         upprättare. I registret behandlas personuppgifter som behövs för att
         underhålla energicertifikatregistret.
       </p>
@@ -134,7 +134,7 @@
       </p>
 
       <p>
-        Ara har lagt ut det tekniska underhållet och utvecklandet av
+        Varke har lagt ut det tekniska underhållet och utvecklandet av
         Energicertifikatregistret på en IT-tjänsteleverantör med vilken det har
         ingåtts ett avtal om användning av personuppgifter enligt
         dataskyddsförordningen.
@@ -156,7 +156,7 @@
 
       <p>
         Lagringsperioderna för personuppgifter i Energicertifikatregistret
-        grundar sig i lagstiftning och Aras informationsstyrningsplan.
+        grundar sig i lagstiftning och Varkes informationsstyrningsplan.
       </p>
 
       <H3>Den registrerades rättigheter</H3>
@@ -205,17 +205,17 @@
 
       <H3>Personuppgiftsansvarig</H3>
       <ul class="contact-info">
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>PB 30, 15141 Lahtis</li>
-        <li>Telefon: 029 525 0800 (växel)</li>
-        <li>E-post: kirjaamo.ara(at)ara.fi</li>
+        <li>Centralen föt statligt stött bostadsbyggande (Varke)</li>
+        <li>PB 35, 00023 Statsrådet</li>
+        <li>Telefon: 0295 16001(växel)</li>
+        <li>E-post: kirjaamo.ara(at)varke.fi</li>
       </ul>
 
       <H3>Kontaktperson i ärenden som gäller registret</H3>
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energiexpert</li>
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>förnamn.efternamn(at)ara.fi</li>
+        <li>Kimmo Huovinen, biträdande direktör</li>
+        <li>Centralen föt statligt stött bostadsbyggande (Varke)</li>
+        <li>förnamn.efternamn(at)gov.fi</li>
       </ul>
     </div>
   </div>

--- a/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-fi.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-fi.svelte
@@ -166,9 +166,9 @@
       </p>
 
       <p>
-        Varke on ulkoistanut laatijarekisterin teknisen ylläpidon ja kehittämisen
-        IT-palveluntarjoajalle, jonka kanssa on laadittu tietosuoja-asetuksen
-        mukainen sopimus henkilötietojen käsittelystä.
+        Varke on ulkoistanut laatijarekisterin teknisen ylläpidon ja
+        kehittämisen IT-palveluntarjoajalle, jonka kanssa on laadittu
+        tietosuoja-asetuksen mukainen sopimus henkilötietojen käsittelystä.
       </p>
 
       <p>

--- a/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-fi.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-fi.svelte
@@ -68,7 +68,7 @@
       </p>
 
       <p>
-        Aran lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
+        Varken lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
         laatijoita. Rekisterissä käsitellään henkilötietoja, jotka tarvitaan
         energiatodistusten laatijarekisterin ylläpitämiseksi. Osaa rekisterin
         tiedoista pidetään esillä julkisessa tietopalvelussa. Henkilötietoja
@@ -153,7 +153,7 @@
       </p>
 
       <p>
-        Aran verkkosivujen kautta on julkisesti haettavissa kaikkien
+        Varken verkkosivujen kautta on julkisesti haettavissa kaikkien
         rekisteröityneiden nimi, toiminta-alue ja laatijapätevyyden voimassaolo.
         Rekisteröidyt voivat itse määritellä myös osoitteen, puhelinnumeron,
         sähköpostiosoitteen ja verkkosivun julkisesti saataville.
@@ -166,7 +166,7 @@
       </p>
 
       <p>
-        Ara on ulkoistanut laatijarekisterin teknisen ylläpidon ja kehittämisen
+        Varke on ulkoistanut laatijarekisterin teknisen ylläpidon ja kehittämisen
         IT-palveluntarjoajalle, jonka kanssa on laadittu tietosuoja-asetuksen
         mukainen sopimus henkilötietojen käsittelystä.
       </p>
@@ -180,7 +180,7 @@
 
       <p>
         Energiatodistusten laatijarekisterin sisältämien henkilötietojen
-        säilytysajat pohjautuvat Aran tiedonohjaussuunnitelmaan.
+        säilytysajat pohjautuvat Varken tiedonohjaussuunnitelmaan.
       </p>
 
       <H3>Rekisteröidyn oikeudet</H3>
@@ -220,14 +220,14 @@
         </li>
         <li>
           laatijapätevyyden voimassaoloaika päättyy eikä pätevyyden toteaja ole
-          ilmoittanut pätevyyden uusimisesta Aralle;
+          ilmoittanut pätevyyden uusimisesta Varkelle;
         </li>
         <li>laatijalle on annettu todistusten laatimiskielto;</li>
         <li>
           laatijan osalta toiminnan harjoittamisen yleiset edellytykset eivät
           enää täyty;
         </li>
-        <li>Ara on saanut tiedon laatijan kuolemasta.</li>
+        <li>Varke on saanut tiedon laatijan kuolemasta.</li>
       </ol>
 
       <p>
@@ -261,18 +261,18 @@
       <H3>Rekisterinpitäjä</H3>
 
       <ul class="contact-info">
-        <li>Asumisen rahoitus- ja kehittämiskeskus (Ara)</li>
-        <li>PL 30, 15141 Lahti</li>
-        <li>Puhelin: 029 525 0800 (vaihde)</li>
-        <li>Sähköposti: kirjaamo.ara(at)ara.fi</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>PL 35, 0023 Valtioneuvosto</li>
+        <li>Puhelin: 0295 16001 (vaihde)</li>
+        <li>Sähköposti: varke.ym(at)gov.fi</li>
       </ul>
 
       <H3>Yhteyshenkilö</H3>
 
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energia-asiantuntija</li>
-        <li>Asumisen rahoitus- ja kehittämiskeskus</li>
-        <li>etunimi.sukunimi(at)ara.fi</li>
+        <li>Kimmo Huovinen, apulaisjohtaja</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>etunimi.sukunimi(at)gov.fi</li>
       </ul>
     </div>
   </div>

--- a/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-sv.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-sv.svelte
@@ -67,7 +67,7 @@
       </p>
 
       <p>
-        Aras lagstadgade uppgift är att övervaka energicertifikat och deras
+        Varkes lagstadgade uppgift är att övervaka energicertifikat och deras
         upprättare. I registret behandlas personuppgifter som behövs för att
         underhålla registret över upprättare av energicertifikat. En del av
         uppgifterna ska vara tillgängliga genom den offentliga
@@ -152,7 +152,7 @@
       </p>
 
       <p>
-        På Aras webbplats kan man offentligt söka alla registrerades namn,
+        På Varkes webbplats kan man offentligt söka alla registrerades namn,
         verksamhetsområden och giltighet för upprättarbehörighet. Registrerade
         kan även själv göra adress, telefonnummer, e-postadress och webbplats
         offentligt tillgängliga.
@@ -165,7 +165,7 @@
       </p>
 
       <p>
-        Ara har lagt ut energicertifikatregistrets tekniska underhåll och
+        Varke har lagt ut energicertifikatregistrets tekniska underhåll och
         utveckling åt en extern IT-tjänsteleverantör genom ett avtal enligt
         dataskyddsförordningen angående behandlingen av personuppgifter.
       </p>
@@ -179,7 +179,7 @@
 
       <p>
         Lagringsperioderna för personuppgifter i register för upprättare av
-        energicertifikat grundar sig i lagstiftning och Aras
+        energicertifikat grundar sig i lagstiftning och Varkes
         informationsstyrningsplan.
       </p>
 
@@ -224,7 +224,7 @@
         <li>
           när giltighetstiden för behörigheten att upprätta energicertifikat
           löper ut och den som konstaterar behörigheten inte har meddelat
-          Finansierings- och utvecklingscentralen för boendet att behörigheten
+          Varke att behörigheten
           förnyas,
         </li>
         <li>
@@ -236,7 +236,7 @@
           bedriva verksamhet,
         </li>
         <li>
-          när Finansierings- och utvecklingscentralen för boendet har erhållit
+          när Varke har erhållit
           information om att upprättaren har avlidit.
         </li>
       </ol>
@@ -275,18 +275,18 @@
       <H3>Personuppgiftsansvarig</H3>
 
       <ul class="contact-info">
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>PB 30, 15141 Lahtis</li>
-        <li>Telefon: 029 525 0800 (växel)</li>
-        <li>E-post: kirjaamo.ara(at)ara.fi</li>
+        <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+        <li>PB 35, 00023 Statsrådet</li>
+        <li>Telefon: 0295 16001 (växel)</li>
+        <li>E-post: varke.ym(at)gov.fi</li>
       </ul>
 
       <H3>Kontaktperson i ärenden som gäller registret</H3>
 
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energiexpert</li>
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>förnamn.efternamn(at)ara.fi</li>
+        <li>Kimmo Huovinen, biträdande direktör</li>
+        <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+        <li>förnamn.efternamn(at)gov.fi</li>
       </ul>
     </div>
   </div>

--- a/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-sv.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-laatijarekisteri-sv.svelte
@@ -223,9 +223,8 @@
         </li>
         <li>
           när giltighetstiden för behörigheten att upprätta energicertifikat
-          löper ut och den som konstaterar behörigheten inte har meddelat
-          Varke att behörigheten
-          förnyas,
+          löper ut och den som konstaterar behörigheten inte har meddelat Varke
+          att behörigheten förnyas,
         </li>
         <li>
           om upprättaren av energicertifikat meddelas ett förbud att upprätta
@@ -236,8 +235,7 @@
           bedriva verksamhet,
         </li>
         <li>
-          när Varke har erhållit
-          information om att upprättaren har avlidit.
+          när Varke har erhållit information om att upprättaren har avlidit.
         </li>
       </ol>
 

--- a/etp-public/src/pages/tietosuojaseloste-valvontatietorekisteri-fi.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-valvontatietorekisteri-fi.svelte
@@ -217,7 +217,8 @@
       <ul class="contact-info">
         <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
         <li>PL 35, 00023 Valtioneuvosto</li>
-        <li>Puhelin: 0295 16001 (vaihde)<li>
+        <li>Puhelin: 0295 16001 (vaihde)</li>
+        <li></li>
         <li>Sähköposti: varke.ym(at)gov.fi</li>
       </ul>
 

--- a/etp-public/src/pages/tietosuojaseloste-valvontatietorekisteri-fi.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-valvontatietorekisteri-fi.svelte
@@ -64,9 +64,9 @@
       </p>
 
       <p>
-        Aran lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
+        Varken lakisääteisenä tehtävänä on valvoa energiatodistuksia ja niiden
         laatijoita. Rekisterissä käsitellään henkilötietoja, jotka tarvitaan
-        energiatodistusten valvontatietorekisterin ylläpitämiseksi. Ara valvoo
+        energiatodistusten valvontatietorekisterin ylläpitämiseksi. Varke valvoo
         energiatodistusten käyttöä ja oikeellisuutta sekä laatijoiden toimintaa.
       </p>
 
@@ -135,7 +135,7 @@
 
       <p>
         Tietojärjestelmän tekninen ylläpito ja kehittäminen on ulkoistettu
-        IT-palveluntarjoajalle. Ara on tehnyt palveluntarjoajan kanssa
+        IT-palveluntarjoajalle. Varke on tehnyt palveluntarjoajan kanssa
         tietosuoja-asetuksen mukaisen sopimuksen henkilötietojen käsittelystä.
       </p>
 
@@ -157,7 +157,7 @@
 
       <p>
         Energiatodistusten valvontatietorekisterin sisältämien henkilötietojen
-        säilytysajat pohjautuvat Aran tiedonohjaussuunnitelmaan.
+        säilytysajat pohjautuvat Varken tiedonohjaussuunnitelmaan.
       </p>
 
       <H3>Rekisteröidyn oikeudet</H3>
@@ -215,18 +215,18 @@
       <H3>Rekisterinpitäjä</H3>
 
       <ul class="contact-info">
-        <li>Asumisen rahoitus- ja kehittämiskeskus (Ara)</li>
-        <li>PL 30, 15141 Lahti</li>
-        <li>Puhelin: 029 525 0800 (vaihde)</li>
-        <li>Sähköposti: kirjaamo.ara(at)ara.fi</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>PL 35, 00023 Valtioneuvosto</li>
+        <li>Puhelin: 0295 16001 (vaihde)<li>
+        <li>Sähköposti: varke.ym(at)gov.fi</li>
       </ul>
 
       <H3>Yhteyshenkilö</H3>
 
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energia-asiantuntija</li>
-        <li>Asumisen rahoitus- ja kehittämiskeskus</li>
-        <li>etunimi.sukunimi(at)ara.fi</li>
+        <li>Kimmo Huovinen, apulaisjohtaja</li>
+        <li>Valtion tukeman asuntorakentamisen keskus (Varke)</li>
+        <li>etunimi.sukunimi(at)gov.fi</li>
       </ul>
     </div>
   </div>

--- a/etp-public/src/pages/tietosuojaseloste-valvontatietorekisteri-sv.svelte
+++ b/etp-public/src/pages/tietosuojaseloste-valvontatietorekisteri-sv.svelte
@@ -63,13 +63,13 @@
       </p>
 
       <p>
-        Aras lagstadgade uppgift är övervaka energicertifikat och deras
+        Varkes lagstadgade uppgift är övervaka energicertifikat och deras
         upprättare. I registret behandlas personuppgifter som behövs för att
         underhålla registret för övervakningsuppgifter om energicertifikat.
       </p>
 
       <p>
-        Ara övervakar användningen och riktigheten av energicertifikaten samt
+        Varke övervakar användningen och riktigheten av energicertifikaten samt
         deras upprättarens verksamhet.
       </p>
 
@@ -139,7 +139,7 @@
       </p>
 
       <p>
-        Ara har lagt ut registrets tekniska underhåll och utveckling åt en
+        Varke har lagt ut registrets tekniska underhåll och utveckling åt en
         extern IT-tjänsteleverantör genom ett avtal enligt
         dataskyddsförordningen angående behandlingen av personuppgifter.
       </p>
@@ -162,7 +162,7 @@
 
       <p>
         Lagringsperioderna för personuppgifter i registret för
-        övervakningsuppgifter om energicertifikat grundar sig i Aras
+        övervakningsuppgifter om energicertifikat grundar sig i Varkes
         informationsstyrningsplan.
       </p>
 
@@ -222,18 +222,18 @@
       <H3>Personuppgiftsansvarig</H3>
 
       <ul class="contact-info">
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>PB 30, 15141 Lahtis</li>
-        <li>Tfn (växel): 029 525 0800</li>
-        <li>E-post: E-post adress: kirjaamo.ara(at)ara.fi</li>
+        <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+        <li>PB 35, 00023 Statsrådet</li>
+        <li>Tfn (växel): 0295 16001</li>
+        <li>E-post: E-post adress: varke.ym(at)gov.fi</li>
       </ul>
 
       <H3>Kontaktperson i ärenden som gäller registret</H3>
 
       <ul class="contact-info">
-        <li>Kirsi Unhonen, energiexpert</li>
-        <li>Finansierings- och utvecklingscentralen för boendet (Ara)</li>
-        <li>fornamn.efternamn(at)ara.fi</li>
+        <li>Kimmo Huovinen, biträdande direktör</li>
+        <li>Centralen för statligt stött bostadsbyggande (Varke)</li>
+        <li>fornamn.efternamn(at)gov.fi</li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Muutettu julkisen ja priva puolen selosteiden tekstit Varke-muotoon. Lisäksi päivitetty sähköpostiosotteita sekä linkkejä. Saavutettavuusselostetta ei ole päivitetty sillä viestinnän yhteissähköpostia ei ole tiedossa.