### PR TITLE
AE-1851: Set max-lifetime to 10 minutes by default in db config

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
@@ -49,8 +49,8 @@
                              :password       (env "DB_PASSWORD" "etp")
                              :database-name  (env "DB_DATABASE" "etp_dev")
                              :current-schema (env "DB_SCHEMA" "etp")
-                             :max-lifetime   (env "DB_MAX_LIFETIME_MS" ten-minutes-in-ms)}
                             opts)})))
+                             :max-lifetime   ten-minutes-in-ms}
 
 (defn http-server
   ([] (http-server {}))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
@@ -40,15 +40,17 @@
 (defn db
   ([] (db {}))
   ([opts]
-   {:solita.etp/db (merge {:adapter        "postgresql"
-                           :server-name    (env "DB_HOST" "localhost")
-                           :port-number    (env "DB_PORT" 5432)
-                           :username       (env "DB_USER" "etp_app")
-                           :read-only      is-public-backend?
-                           :password       (env "DB_PASSWORD" "etp")
-                           :database-name  (env "DB_DATABASE" "etp_dev")
-                           :current-schema (env "DB_SCHEMA" "etp")}
-                          opts)}))
+   (let [ten-minutes-in-ms 600000]
+     {:solita.etp/db (merge {:adapter        "postgresql"
+                             :server-name    (env "DB_HOST" "localhost")
+                             :port-number    (env "DB_PORT" 5432)
+                             :username       (env "DB_USER" "etp_app")
+                             :read-only      is-public-backend?
+                             :password       (env "DB_PASSWORD" "etp")
+                             :database-name  (env "DB_DATABASE" "etp_dev")
+                             :current-schema (env "DB_SCHEMA" "etp")
+                             :max-lifetime   (env "DB_MAX_LIFETIME_MS" ten-minutes-in-ms)}
+                            opts)})))
 
 (defn http-server
   ([] (http-server {}))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
@@ -36,11 +36,10 @@
 ;;
 ;; For Integrant components
 ;;
-
+(def ^:private ten-minutes-in-ms 600000)
 (defn db
   ([] (db {}))
   ([opts]
-   (let [ten-minutes-in-ms 600000]
      {:solita.etp/db (merge {:adapter        "postgresql"
                              :server-name    (env "DB_HOST" "localhost")
                              :port-number    (env "DB_PORT" 5432)
@@ -49,8 +48,8 @@
                              :password       (env "DB_PASSWORD" "etp")
                              :database-name  (env "DB_DATABASE" "etp_dev")
                              :current-schema (env "DB_SCHEMA" "etp")
-                            opts)})))
                              :max-lifetime   ten-minutes-in-ms}
+                            opts)}))
 
 (defn http-server
   ([] (http-server {}))


### PR DESCRIPTION
Set max-lifetime to 10 minutes by default in db config. Also introduce "DB_MAX_LIFETIME_MS" to be able to fine-tune it later.