### PR TITLE
Feature/ae 2502 suomifi viestit rest

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/config.clj
@@ -166,6 +166,9 @@
 (def suomifi-viestit-keystore-password (env "SUOMIFI_VIESTIT_KEYSTORE_PASSWORD" nil))
 (def suomifi-viestit-keystore-alias (env "SUOMIFI_VIESTIT_KEYSTORE_ALIAS" nil))
 
+(def suomifi-viestit-rest-base-url (env "SUOMIFI_VIESTIT_REST_BASE_URL" nil))
+(def suomifi-viestit-rest-password (env "SUOMIFI_VIESTIT_REST_PASSWORD" nil))
+
 ;; DVV / Järjestelmäallekirjoitus
 (def system-signature-certificate-leaf (env-or-resource "SYSTEM_SIGNATURE_CERTIFICATE_LEAF" "system-signature/local-signing-leaf.pem.crt"))
 (def system-signature-certificate-intermediate (env-or-resource "SYSTEM_SIGNATURE_CERTIFICATE_INTERMEDIATE" "system-signature/local-signing-int.pem.crt"))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/exception_email_handler.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/exception_email_handler.clj
@@ -25,7 +25,12 @@
 
    :suomifi-viestit-failure          {:subject "Suomifi viestin lähetys epäonnistui: {{request.sanoma-tunniste}}"
                                       :body    (str "Suomifi viestin lähettäminen epäonnistui\n"
-                                                    "- Sanoman tunniste: {{request.sanoma.tunniste}}")}})
+                                                    "- Sanoman tunniste: {{request.sanoma.tunniste}}")}
+
+   :suomifi-viestit-rest-api-failure {:subject "Suomifi viestin lähetys epäonnistui: {{external-id}}"
+                                      :body    (str "Suomifi viestin lähettäminen REST-rajapinnan kautta epäonnistui\n"
+                                                    "- Viestin extrenalId: {{external-id}}\n\n"
+                                                    "Etsi logeista externalId:llä, niin voit päätellä, mihin lähettäminen on kaatunut.")}})
 
 (defn- prepare-email [{:keys [subject body]} data]
   (let [config (update-in ch/default-config

--- a/etp-core/etp-backend/src/main/clj/solita/etp/retry.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/retry.clj
@@ -1,0 +1,24 @@
+(ns solita.etp.retry
+  (:require [clojure.tools.logging :as log]))
+
+(defn run-with-retries [f retry-count op-description]
+  "Attempt to run function `f` and return its value. If an exception happens,
+  log it at error level and try running the function again at most `retry-count`
+  times, until it succeeds. If there is no success within the retry count limit,
+  throw the last exception"
+  (loop [retry-count retry-count]
+    (let [[res e]
+          (try
+            [(f) nil]
+            (catch Exception e
+              (log/error e "Exception in attempting to" (str op-description ":"))
+              [nil e]))]
+
+      (if e
+        (if (< 0 retry-count)
+          (do
+            (log/info "Retrying " op-description " in 500 ms")
+            (Thread/sleep 500)
+            (recur (dec retry-count)))
+          (throw e))
+        res))))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit.clj
@@ -146,6 +146,24 @@
            (read-response request)
            (assert-tila-koodi! request)))
 
+(defn merge-default-config [config]
+  (merge {:rest-base-url        config/suomifi-viestit-rest-base-url
+          :rest-password        config/suomifi-viestit-rest-password
+          :viranomaistunnus     config/suomifi-viestit-viranomaistunnus
+          :palvelutunnus        config/suomifi-viestit-palvelutunnus
+          :varmenne             config/suomifi-viestit-varmenne
+          :tulostustoimittaja   config/suomifi-viestit-tulostustoimittaja
+          :yhteyshenkilo-nimi   config/suomifi-viestit-yhteyshenkilo-nimi
+          :yhteyshenkilo-email  config/suomifi-viestit-yhteyshenkilo-email
+          :laskutus-tunniste    config/suomifi-viestit-laskutus-tunniste
+          :laskutus-salasana    config/suomifi-viestit-laskutus-salasana
+          :paperitoimitus?      config/suomifi-viestit-paperitoimitus?
+          :laheta-tulostukseen? config/suomifi-viestit-laheta-tulostukseen?
+          :keystore-file        config/suomifi-viestit-keystore-file
+          :keystore-password    config/suomifi-viestit-keystore-password
+          :keystore-alias       config/suomifi-viestit-keystore-alias}
+         config))
+
 (defn send-message! [sanoma
                      kohde
                      & [{:keys [viranomaistunnus palvelutunnus varmenne tulostustoimittaja

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -93,16 +93,15 @@
 
   Returns: response?"
   [{:keys [pdf-file] :as message-info} &
-   [{:keys [viranomaistunnus palvelutunnus yhteyshenkilo-email
-            laskutus-tunniste laskutus-salasana rest-salasana]
-     :or   {viranomaistunnus     config/suomifi-viestit-viranomaistunnus
-            palvelutunnus        config/suomifi-viestit-palvelutunnus
-            yhteyshenkilo-email  config/suomifi-viestit-yhteyshenkilo-email
-            laskutus-tunniste    config/suomifi-viestit-laskutus-tunniste
-            laskutus-salasana    config/suomifi-viestit-laskutus-salasana
-            rest-salasana        config/suomifi-viestit-rest-password}
-     :as   config}]]
-  (let [access-token (get-access-token! config)
+   [config]]
+  (let [default-config {:viranomaistunnus     config/suomifi-viestit-viranomaistunnus
+                        :palvelutunnus        config/suomifi-viestit-palvelutunnus
+                        :yhteyshenkilo-email  config/suomifi-viestit-yhteyshenkilo-email
+                        :laskutus-tunniste    config/suomifi-viestit-laskutus-tunniste
+                        :laskutus-salasana    config/suomifi-viestit-laskutus-salasana
+                        :rest-salasana        config/suomifi-viestit-rest-password}
+        config (merge default-config config)
+        access-token (get-access-token! config)
         attachment-ref (send-attachment-pdf! access-token pdf-file)
         request (-> message-info
                     (dissoc :pdf-file)

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -26,7 +26,7 @@
                        :status status})))
     (:access_token (:body response))))
 
-(defn- post-attachment-pdf! [access-token pdf-file pdf-file-name {:keys [rest-base-url]}]
+(defn post-attachment-pdf! [access-token pdf-file pdf-file-name {:keys [rest-base-url]}]
   (let [request {:as        :json
                  :multipart [{:name      pdf-file-name
                               :part-name "file"
@@ -36,7 +36,8 @@
         response (*post!* (str rest-base-url "/v2/attachments")
                           (with-access-token access-token request))]
     (when (not (= 201 (:status response)))
-      (throw (ex-info "Failed to send attachment to Suomifi viestit REST API"
+      (throw (ex-info (str "Failed to send attachment to Suomifi viestit REST API: Expected 201 Created, but got "
+                           (:status response))
                       {:type    :suomifi-viestit-rest-attachment-send
                        :status  (:status response)
                        :response (:body response)})))
@@ -87,7 +88,7 @@
                                                                          :password       (:laskutus-salasana config)
                                                                          :username       (:laskutus-tunniste config)}}})))
 
-(defn- post-suomifi-message! [message-info attachment-ref access-token config]
+(defn post-suomifi-message! [message-info attachment-ref access-token config]
   (let [[msg-endpoint msg-fn] (if (or (str/blank? (:laskutus-tunniste config))
                                       (str/blank? (:laskutus-salasana config)))
                                 (do
@@ -160,11 +161,11 @@
                                yhteyshenkilo-email]}]
   (flatten
     [(if (str/blank? rest-base-url)
-       ["base-url is missing"]
+       ["rest-base-url is missing"]
        (try
          (URI. rest-base-url)
          []
-         (catch Exception _ [(str "Invalid base URL: " rest-base-url)])))
+         (catch Exception _ [(str "Invalid rest-base-url: " rest-base-url)])))
      (if (str/blank? palvelutunnus) ["palvelutunnus is missing"] [])
      (if (str/blank? rest-password) ["rest-password is missing"] [])
      (if (str/blank? viranomaistunnus) ["viranomaistunnus is missing"] [])

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -22,15 +22,15 @@
 
 (defn- post-json!
   ([url request access-token]
-   (post-json! url (with-access-token access-token request)))
-  ([url request]
-   (*post!* url (merge request {:content-type :json
-                                :as           :json}))))
+   (*post!* url (merge (with-access-token access-token request) {:content-type :json
+                                                                 :as           :json}))))
 
 (defn- get-access-token! [config]
-  (let [response (post-json! token-endpoint {:form-params
-                                             {:password (:rest-salasana config)
-                                              :username (:viranomaistunnus config)}})]
+  (let [response (*post!* token-endpoint {:content-type :json
+                                          :as           :json
+                                          :form-params
+                                          {:password (:rest-salasana config)
+                                           :username (:viranomaistunnus config)}})]
     (:access_token (:body response))))
 
 (defn- send-attachment-pdf! [access-token pdf-file pdf-file-name]
@@ -95,12 +95,12 @@
   Returns: response?"
   [{:keys [pdf-file pdf-file-name] :as message-info} &
    [config]]
-  (let [default-config {:viranomaistunnus     config/suomifi-viestit-viranomaistunnus
-                        :palvelutunnus        config/suomifi-viestit-palvelutunnus
-                        :yhteyshenkilo-email  config/suomifi-viestit-yhteyshenkilo-email
-                        :laskutus-tunniste    config/suomifi-viestit-laskutus-tunniste
-                        :laskutus-salasana    config/suomifi-viestit-laskutus-salasana
-                        :rest-salasana        config/suomifi-viestit-rest-password}
+  (let [default-config {:viranomaistunnus    config/suomifi-viestit-viranomaistunnus
+                        :palvelutunnus       config/suomifi-viestit-palvelutunnus
+                        :yhteyshenkilo-email config/suomifi-viestit-yhteyshenkilo-email
+                        :laskutus-tunniste   config/suomifi-viestit-laskutus-tunniste
+                        :laskutus-salasana   config/suomifi-viestit-laskutus-salasana
+                        :rest-salasana       config/suomifi-viestit-rest-password}
         config (merge default-config config)
         access-token (get-access-token! config)
         attachment-ref (send-attachment-pdf! access-token pdf-file pdf-file-name)

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -72,7 +72,7 @@
                                                                 :password       (:laskutus-salasana config)
                                                                 :username       (:laskutus-tunniste config)}}}
    :recipient  {:id recipient-id}
-   :sender     {:serviceId "ara_ws_energiatodistus"}})
+   :sender     {:serviceId (:palvelutunnus config)}})
 
 (defn send-suomifi-viesti-with-pdf-attachment!
   "Sends a Suomi.fi-viesti that has the `pdf-file` as an attachment.

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -42,7 +42,6 @@
                        :response (:body response)})))
     (:body response)))
 
-;; Stable API
 (defn ->messages [{:keys [attachments title body external-id recipient-id city country-code name street-address zip-code]} config]
   {:electronic {:bodyFormat         "Text"
                 :messageServiceType "Normal"

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -1,0 +1,111 @@
+(ns solita.etp.service.suomifi-viestit-rest
+  (:require [clj-http.client :as http]
+            [clojure.tools.logging :as log]
+            [solita.etp.config :as config]))
+
+(def base-url config/suomifi-viestit-rest-base-url)
+(def token-endpoint (str base-url "/v1/token"))
+(def attachment-endpoint (str base-url "/v2/attachments"))
+(def messages-endpoint (str base-url "/v2/messages"))
+
+;; Wrapper for post so that can be bound in tests.
+(defn- ^:private ^:dynamic *post!* [url request]
+  (if base-url
+    (http/post url (merge {:throw-exceptions false}
+                          request))
+    (do (log/info "Missing suomifi viestit rest base. Skipping request to suomifi viestit...")
+        (:status 200))))
+
+(defn- with-access-token [access-token request]
+  (let [auth-header {"Authorization" (str "Bearer " access-token)}]
+    (update request :headers #(merge auth-header (or % {})))))
+
+(defn- post-json!
+  ([url request access-token]
+   (post-json! url (with-access-token access-token request)))
+  ([url request]
+   (*post!* url (merge request {:content-type :json
+                                :as           :json}))))
+
+(defn- get-access-token! [config]
+  (let [response (post-json! token-endpoint {:form-params
+                                             {:password (:rest-salasana config)
+                                              :username (:viranomaistunnus config)}})]
+    (:access_token (:body response))))
+
+(defn- send-attachment-pdf! [access-token pdf-file]
+  (let [request {:as :json
+                 :multipart
+                 [{:name "file" :content pdf-file}
+                  {:name "Content/type" :content "application/pdf"}]}]
+    (:body (*post!* attachment-endpoint (with-access-token access-token request)))))
+
+;; Stable API
+(defn ->messages [{:keys [attachments title body external-id recipient-id city country-code name street-address zip-code]} config]
+  {:electronic {:bodyFormat         "Text"
+                :messageServiceType "Normal"
+                :attachments        attachments
+                :title              title
+                :notifications      {:senderDetailsInNotifications "Organisation and service name"
+                                     :unreadMessageNotification    {:reminder "Default reminder"}}
+                :replyAllowedBy     "No one"
+                :body               body
+                :visibility         "Normal"}
+   :externalId external-id
+   :paperMail  {:messageServiceType           "Normal"
+                :createAddressPage            false
+                :rotateLandscapePages         true
+                :attachments                  attachments
+                :recipient                    {:address {:city          city
+                                                         :countryCode   country-code
+                                                         :name          name
+                                                         :streetAddress street-address
+                                                         :zipCode       zip-code}}
+                :sender                       {:address {:city          "Valtioneuvosto"
+                                                         :countryCode   "FI"
+                                                         :name          "Ympäristöministeriö, Valtion tukeman asuntorakentamisen keskus"
+                                                         :streetAddress "PL 35"
+                                                         :zipCode       "00023"}}
+                :twoSidedPrinting             true
+                :colorPrinting                true
+                :printingAndEnvelopingService {:postiMessaging {:contactDetails {:email (:yhteyshenkilo-email config)}
+                                                                :password       (:laskutus-salasana config)
+                                                                :username       (:laskutus-tunniste config)}}}
+   :recipient  {:id recipient-id}
+   :sender     {:serviceId "ara_ws_energiatodistus"}})
+
+(defn send-suomifi-viesti-with-pdf-attachment!
+  "Sends a Suomi.fi-viesti that has the `pdf-file` as an attachment.
+
+  The function expects a map containing the following keys:
+
+  Required keys:
+  - :pdf-file       InputStream  - The PDF attachment that already has address page for paper mail.
+  - :title          string       - The title of the message.
+  - :body           string       - The body of the message.
+  - :external-id    string       – A unique identifier for the message (tunniste).
+  - :recipient-id   string       – The ID (hetu or y-tunnus) of the user submitting the job.
+  - :city           string       - The recipient's city.
+  - :country-code   string       - The recipient's country code.
+  - :name           string       - The recipient's name.
+  - :street-address string       - The recipient's street address.
+  - :zip-code       string       - The recipient's zip code.
+
+  Returns: response?"
+  [{:keys [pdf-file] :as message-info} &
+   [{:keys [viranomaistunnus palvelutunnus yhteyshenkilo-email
+            laskutus-tunniste laskutus-salasana rest-salasana]
+     :or   {viranomaistunnus     config/suomifi-viestit-viranomaistunnus
+            palvelutunnus        config/suomifi-viestit-palvelutunnus
+            yhteyshenkilo-email  config/suomifi-viestit-yhteyshenkilo-email
+            laskutus-tunniste    config/suomifi-viestit-laskutus-tunniste
+            laskutus-salasana    config/suomifi-viestit-laskutus-salasana
+            rest-salasana        config/suomifi-viestit-rest-password}
+     :as   config}]]
+  (let [access-token (get-access-token! config)
+        attachment-ref (send-attachment-pdf! access-token pdf-file)
+        request (-> message-info
+                    (dissoc :pdf-file)
+                    (assoc :attachments [attachment-ref])
+                    (->messages config))]
+    (post-json! messages-endpoint {:form-params request} access-token)))

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -33,11 +33,11 @@
                                               :username (:viranomaistunnus config)}})]
     (:access_token (:body response))))
 
-(defn- send-attachment-pdf! [access-token pdf-file]
+(defn- send-attachment-pdf! [access-token pdf-file pdf-file-name]
   (let [request {:as :json
                  :multipart
-                 [{:name "file" :content pdf-file}
-                  {:name "Content/type" :content "application/pdf"}]}]
+                 [{:name pdf-file-name :part-name "file" :content pdf-file :mime-type "application/pdf"}
+                  ]}]
     (:body (*post!* attachment-endpoint (with-access-token access-token request)))))
 
 ;; Stable API
@@ -81,6 +81,7 @@
 
   Required keys:
   - :pdf-file       InputStream  - The PDF attachment that already has address page for paper mail.
+  - :pdf-file-name  string       - The name used for the PDF attachment.
   - :title          string       - The title of the message.
   - :body           string       - The body of the message.
   - :external-id    string       – A unique identifier for the message (tunniste).
@@ -92,7 +93,7 @@
   - :zip-code       string       - The recipient's zip code.
 
   Returns: response?"
-  [{:keys [pdf-file] :as message-info} &
+  [{:keys [pdf-file pdf-file-name] :as message-info} &
    [config]]
   (let [default-config {:viranomaistunnus     config/suomifi-viestit-viranomaistunnus
                         :palvelutunnus        config/suomifi-viestit-palvelutunnus
@@ -102,7 +103,7 @@
                         :rest-salasana        config/suomifi-viestit-rest-password}
         config (merge default-config config)
         access-token (get-access-token! config)
-        attachment-ref (send-attachment-pdf! access-token pdf-file)
+        attachment-ref (send-attachment-pdf! access-token pdf-file pdf-file-name)
         request (-> message-info
                     (dissoc :pdf-file)
                     (assoc :attachments [attachment-ref])

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/suomifi_viestit.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/suomifi_viestit.clj
@@ -2,7 +2,7 @@
   (:require [clostache.parser :as clostache]
             [clojure.tools.logging :as log]
             [solita.etp.service.valvonta-kaytto.toimenpide :as toimenpide]
-            [solita.etp.service.suomifi-viestit :as suomifi]
+            [solita.etp.service.suomifi-viestit :as suomifi-soap]
             [solita.etp.service.suomifi-viestit-rest :as suomifi-rest]
             [clojure.java.io :as io]
             [solita.etp.service.pdf :as pdf]
@@ -191,7 +191,7 @@
                                  osapuoli
                                  document
                                  & [config]]
-  (suomifi/send-message!
+  (suomifi-soap/send-message!
     (->sanoma toimenpide osapuoli)
     (->kohde valvonta toimenpide osapuoli document)
     config))
@@ -201,7 +201,8 @@
                              toimenpide
                              osapuolet
                              & [config]]
-  (let [rest-config-problems (suomifi-rest/validate-config config)
+  (let [config (suomifi-soap/merge-default-config config)
+        rest-config-problems (suomifi-rest/validate-config config)
         send-to-osapuoli! (if (seq rest-config-problems)
                             (do
                               (log/info "Not sending via REST API due to configuration issues: " rest-config-problems)

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/suomifi_viestit.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/valvonta_kaytto/suomifi_viestit.clj
@@ -150,7 +150,9 @@
   (let [type-key (toimenpide/type-key (:type-id toimenpide))
         {:keys [nimike kuvaus]} (toimenpide->kohde type-key valvonta toimenpide)
         asiakas (osapuoli->asiakas osapuoli)
+        tiedosto (toimenpide->tiedosto type-key)
         params {:pdf-file       document
+                :pdf-file-name  (:nimi tiedosto)
                 :title          nimike
                 :body           kuvaus
                 :external-id    (tunniste toimenpide osapuoli)

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/suomifi_viestit_rest_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/suomifi_viestit_rest_test.clj
@@ -1,0 +1,157 @@
+(ns solita.etp.service.suomifi-viestit-rest-test
+  (:require [clojure.string :as str]
+            [clojure.test :as t]
+            [solita.etp.service.suomifi-viestit-rest :as rest-service])
+  (:import (java.io ByteArrayInputStream)))
+
+(def electronic-config
+  {:rest-base-url    "http://example.com"
+   :rest-password    "password"
+   :viranomaistunnus "testuser"
+   :palvelutunnus     "service-id"
+   :yhteyshenkilo-email "hello@example.com"})
+
+(def full-config
+  (assoc electronic-config
+    :laskutus-tunniste "dalskjfhadslkjfahsdlf"
+    :laskutus-salasana "asdasdasdasd"))
+
+(t/deftest validate-config-test
+  (t/is (seq (rest-service/validate-config {})))
+  (t/is (seq (rest-service/validate-config {:rest-base-url "http://example.com"
+                                            :rest-password "password"
+                                            :viranomaistunnus "testuser"})))
+  (t/is (not (seq (rest-service/validate-config electronic-config)))))
+
+(t/deftest get-access-token-test
+  (let [url (atom nil)
+        req (atom nil)]
+    (with-bindings {#'rest-service/*post!* (fn [u r]
+                                             (reset! url u)
+                                             (reset! req r)
+                                             {:status 200} ) }
+      (rest-service/get-access-token! full-config))
+    (t/is (= "http://example.com/v1/token" @url))))
+
+(t/deftest post-attachment-pdf-test
+  (let [url (atom nil)
+        req (atom nil)]
+    (with-bindings {#'rest-service/*post!* (fn [u r]
+                                             (reset! url u)
+                                             (reset! req r)
+                                             {:status 201} ) }
+      (rest-service/post-attachment-pdf! "dummy-access-token"
+                                         (ByteArrayInputStream. (.getBytes "Some dummy content"))
+                                         "ukaasi.pdf"
+                                         full-config))
+    (t/is (= "http://example.com/v2/attachments" @url))))
+
+;; Something to match the first parameter to send-suomifi-viesti-with-pdf-attachment!
+(def dummy-message
+  {:pdf-file       (ByteArrayInputStream. (.getBytes "Some dummy content"))
+   :pdf-file-name  "ukaasi.pdf"
+   :title          "Dummy title"
+   :body           "Dummy body"
+   :external-id    "dummy-external-id"
+   :recipient-id   "dummy-recipient-id"
+   :city           "Dummy City"
+   :country-code   "FI"
+   :name           "Dummy Name"
+   :street-address "Dummy Street Address"
+   :zip-code       "12345"})
+
+(def full-params {:electronic {:attachments        ["dummy-attachment-ref"]
+                               :body               "Dummy body"
+                               :bodyFormat         "Text"
+                               :messageServiceType "Normal"
+                               :notifications      {:senderDetailsInNotifications "Organisation and service name"
+                                                    :unreadMessageNotification    {:reminder "Default reminder"}}
+                               :replyAllowedBy     "No one"
+                               :title              "Dummy title"
+                               :visibility         "Normal"}
+                  :externalId "dummy-external-id"
+                  :paperMail  {:attachments                  ["dummy-attachment-ref"]
+                               :colorPrinting                true
+                               :createAddressPage            false
+                               :messageServiceType           "Normal"
+                               :printingAndEnvelopingService {:postiMessaging {:contactDetails {:email "hello@example.com"}
+                                                                               :password       "asdasdasdasd"
+                                                                               :username       "dalskjfhadslkjfahsdlf"}}
+                               :recipient                    {:address {:city          "Dummy City"
+                                                                        :countryCode   "FI"
+                                                                        :name          "Dummy Name"
+                                                                        :streetAddress "Dummy Street Address"
+                                                                        :zipCode       "12345"}}
+                               :rotateLandscapePages         true
+                               :sender                       {:address {:city          "Valtioneuvosto"
+                                                                        :countryCode   "FI"
+                                                                        :name          "Ympäristöministeriö, Valtion tukeman asuntorakentamisen keskus"
+                                                                        :streetAddress "PL 35"
+                                                                        :zipCode       "00023"}}
+                               :twoSidedPrinting             true}
+                  :recipient  {:id "dummy-recipient-id"}
+                  :sender     {:serviceId "service-id"}})
+
+(def electronic-params (dissoc full-params :paperMail))
+
+(t/deftest post-messages-electronic-test
+  (let [url (atom nil)
+        req (atom nil)]
+    (with-bindings {#'rest-service/*post!* (fn [u r]
+                                             (reset! url u)
+                                             (reset! req r)
+                                             {:status 200} ) }
+      (rest-service/post-suomifi-message! dummy-message
+                                          "dummy-attachment-ref"
+                                          "dummy-access-token"
+                                          electronic-config))
+    (t/is (= "http://example.com/v2/messages/electronic" @url))
+    (t/is (= electronic-params (:form-params @req)))))
+
+(t/deftest post-messages-full-test
+  (let [url (atom nil)
+        req (atom nil)]
+    (with-bindings {#'rest-service/*post!* (fn [u r]
+                                             (reset! url u)
+                                             (reset! req r)
+                                             {:status 200} ) }
+      (rest-service/post-suomifi-message! dummy-message
+                                          "dummy-attachment-ref"
+                                          "dummy-access-token"
+                                          full-config))
+    (t/is (= "http://example.com/v2/messages" @url))
+    (t/is (= full-params (:form-params @req)))))
+
+(t/deftest send-full-seq-test
+  (let [calls (atom [])]
+    (with-bindings {#'rest-service/*post!* (fn [u r]
+                                             (swap! calls (fn [calls] (conj calls {:url u :request r})))
+                                             (cond
+                                               (str/ends-with? u "/v1/token") {:status 200}
+                                               (str/ends-with? u "/v2/attachments") {:status 201}
+                                               (str/ends-with? u "/v2/messages/electronic") {:status 200}
+                                               (str/ends-with? u "/v2/messages") {:status 200}))}
+      (try
+        (rest-service/send-suomifi-viesti-with-pdf-attachment! dummy-message full-config)
+        (catch Exception _ nil)))
+    (t/is (= ["http://example.com/v1/token"
+              "http://example.com/v2/attachments"
+              "http://example.com/v2/messages"]
+             (map :url @calls)))))
+
+(t/deftest send-electronic-seq-test
+  (let [calls (atom [])]
+    (with-bindings {#'rest-service/*post!* (fn [u r]
+                                             (swap! calls (fn [calls] (conj calls {:url u :request r})))
+                                             (cond
+                                               (str/ends-with? u "/v1/token") {:status 200}
+                                               (str/ends-with? u "/v2/attachments") {:status 201}
+                                               (str/ends-with? u "/v2/messages/electronic") {:status 200}
+                                               (str/ends-with? u "/v2/messages") {:status 200}))}
+      (try
+        (rest-service/send-suomifi-viesti-with-pdf-attachment! dummy-message electronic-config)
+        (catch Exception _ nil)))
+    (t/is (= ["http://example.com/v1/token"
+              "http://example.com/v2/attachments"
+              "http://example.com/v2/messages/electronic"]
+             (map :url @calls)))))


### PR DESCRIPTION
Support for the newly added REST API for Suomi.fi Viestit
- Older SOAP based integration is still included
- REST is used only when the required parameters can be found
  in the environment