### PR TITLE
AE-2542: Tietomallin laajennus kattamaan PPP:n laatijapätevyys

### DIFF
--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
@@ -147,8 +147,10 @@
 
 (t/deftest find-patevyydet-test
   (let [patevyydet (service/find-patevyystasot ts/*db*)
-        fi-labels (map :label-fi patevyydet)
-        se-labels (map :label-sv patevyydet)]
+        ; Filter to only test original patevyystaso entries (upcoming PPP features excluded)
+        original-patevyydet (filter #(#{1 2} (:id %)) patevyydet)
+        fi-labels (map :label-fi original-patevyydet)
+        se-labels (map :label-sv original-patevyydet)]
     (t/is (= ["Perustaso" "Ylempi taso"] fi-labels))
     (t/is (= ["Basnivå" "Högre nivå"] se-labels))))
 

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
@@ -147,12 +147,10 @@
 
 (t/deftest find-patevyydet-test
   (let [patevyydet (service/find-patevyystasot ts/*db*)
-        ; Filter to only test original patevyystaso entries (upcoming PPP features excluded)
-        original-patevyydet (filter #(#{1 2} (:id %)) patevyydet)
-        fi-labels (map :label-fi original-patevyydet)
-        se-labels (map :label-sv original-patevyydet)]
-    (t/is (= ["Perustaso" "Ylempi taso"] fi-labels))
-    (t/is (= ["Basnivå" "Högre nivå"] se-labels))))
+        fi-labels (map :label-fi patevyydet)
+        se-labels (map :label-sv patevyydet)]
+    (t/is (= ["Perustaso" "Ylempi taso" "Perustaso + PPP" "Ylempi + PPP"] fi-labels))
+    (t/is (= ["Basnivå" "Högre nivå" "Basnivå + PPP" "Högre nivå + PPP"] se-labels))))
 
 (t/deftest validate-laatija-patevyys!-test
   (let [{:keys [laatijat]} (test-data-set false false)]

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/laatija_test.clj
@@ -149,8 +149,8 @@
   (let [patevyydet (service/find-patevyystasot ts/*db*)
         fi-labels (map :label-fi patevyydet)
         se-labels (map :label-sv patevyydet)]
-    (t/is (= ["Perustaso" "Ylempi taso" "Perustaso + PPP" "Ylempi + PPP"] fi-labels))
-    (t/is (= ["Basnivå" "Högre nivå" "Basnivå + PPP" "Högre nivå + PPP"] se-labels))))
+    (t/is (= #{"Perustaso" "Ylempi taso" "Perustaso + PPP" "Ylempi + PPP"} (set fi-labels)))
+    (t/is (= #{"Basnivå" "Högre nivå" "Basnivå + PPP" "Högre nivå + PPP"} (set se-labels)))))
 
 (t/deftest validate-laatija-patevyys!-test
   (let [{:keys [laatijat]} (test-data-set false false)]

--- a/etp-core/etp-db/src/main/sql/migration/v5-release-1.1/v5.49-add-ppp-patevyystaso.sql
+++ b/etp-core/etp-db/src/main/sql/migration/v5-release-1.1/v5.49-add-ppp-patevyystaso.sql
@@ -1,0 +1,10 @@
+-- Add new patevyystaso for PPP certification
+
+INSERT INTO patevyystaso (id, label_fi, label_sv, valid)
+VALUES 
+  (3, 'Perustaso + PPP', 'Basnivå + PPP', true),
+  (4, 'Ylempi + PPP', 'Högre nivå + PPP', true)
+ON CONFLICT (id) DO UPDATE SET
+  label_fi = EXCLUDED.label_fi,
+  label_sv = EXCLUDED.label_sv,
+  valid = EXCLUDED.valid;

--- a/etp-front/src/pages/laatija/laatijat.svelte
+++ b/etp-front/src/pages/laatija/laatijat.svelte
@@ -244,7 +244,7 @@
               format={Locales.labelForId($locale, patevyydet)}
               parse={Maybe.Some}
               noneLabel={i18nRoot + '.filters.all'}
-              items={R.pluck('id', patevyydet)} />
+              items={R.compose(R.pluck('id'), R.filter(R.propSatisfies(R.includes(R.__, [1, 2]), 'id')))(patevyydet)} />
           </div>
 
           <div class="lg:w-1/3 w-full px-4 py-4">

--- a/etp-front/src/pages/laatija/laatijat.svelte
+++ b/etp-front/src/pages/laatija/laatijat.svelte
@@ -244,7 +244,10 @@
               format={Locales.labelForId($locale, patevyydet)}
               parse={Maybe.Some}
               noneLabel={i18nRoot + '.filters.all'}
-              items={R.compose(R.pluck('id'), R.filter(R.propSatisfies(R.includes(R.__, [1, 2]), 'id')))(patevyydet)} />
+              items={R.compose(
+                R.pluck('id'),
+                R.filter(R.propSatisfies(R.includes(R.__, [1, 2]), 'id'))
+              )(patevyydet)} />
           </div>
 
           <div class="lg:w-1/3 w-full px-4 py-4">


### PR DESCRIPTION
Migraatiolla lisätty kaksi uutta pätevyystasoa.

Nykyiset tasot ovat kovakoodattuna table-laatijahaku-filter.svelte -tiedostossa joten uudet pätevyystasot eivät vielä tule näkyviin.

Kirjautumispalvelun puolella laatijapätevyydet tulivat dynaamisesti näkyviin laatijahaun valikkoon, mutta ne on toistaiseksi suodatettu pois