### PR TITLE
AE-2502: Add address page to paper mail

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -69,7 +69,7 @@
   (-> message
       (->messages-electronic config)
       (assoc :paperMail {:messageServiceType           "Normal"
-                         :createAddressPage            false
+                         :createAddressPage            true
                          :rotateLandscapePages         true
                          :attachments                  attachments
                          :recipient                    {:address {:city          city

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/suomifi_viestit_rest_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/suomifi_viestit_rest_test.clj
@@ -72,7 +72,7 @@
                   :externalId "dummy-external-id"
                   :paperMail  {:attachments                  ["dummy-attachment-ref"]
                                :colorPrinting                true
-                               :createAddressPage            false
+                               :createAddressPage            true
                                :messageServiceType           "Normal"
                                :printingAndEnvelopingService {:postiMessaging {:contactDetails {:email "hello@example.com"}
                                                                                :password       "asdasdasdasd"


### PR DESCRIPTION
Makes Suomi.fi-viestit add an address page to the document that is sent to Posti. We create the address page ourselves to some other cases but those are not sent via Suomi.fi-viestit.