### PR TITLE
Et26 feature flag utility function

### DIFF
--- a/etp-front/src/App.svelte
+++ b/etp-front/src/App.svelte
@@ -18,7 +18,6 @@
   import * as ohjeApi from '@Pages/ohje/ohje-api';
   import * as Future from '@Utility/future-utils';
   import Body from './Body.svelte';
-  import { isEtp2026Enabled } from '@Utility/config_utils.js';
 
   setupI18n();
 
@@ -92,7 +91,7 @@
 
     <div class="footercontainer">
       <div class="w-full max-w-1440 mx-auto">
-        <Footer {version} isEtp2026={isEtp2026Enabled(config)} />
+        <Footer {version} {config} />
       </div>
     </div>
   {/each}

--- a/etp-front/src/App.svelte
+++ b/etp-front/src/App.svelte
@@ -18,6 +18,7 @@
   import * as ohjeApi from '@Pages/ohje/ohje-api';
   import * as Future from '@Utility/future-utils';
   import Body from './Body.svelte';
+  import { isEtp2026Enabled } from '@Utility/config_utils.js';
 
   setupI18n();
 
@@ -91,7 +92,7 @@
 
     <div class="footercontainer">
       <div class="w-full max-w-1440 mx-auto">
-        <Footer {version} isEtp2026={config.isEtp2026 ?? false} />
+        <Footer {version} isEtp2026={isEtp2026Enabled(config)} />
       </div>
     </div>
   {/each}

--- a/etp-front/src/pages/energiatodistus/energiatodistukset.svelte
+++ b/etp-front/src/pages/energiatodistus/energiatodistukset.svelte
@@ -38,6 +38,7 @@
   import * as versionApi from '@Component/Version/version-api';
   import { announcementsForModule } from '@Utility/announce';
   import { announcePolitely } from '@Utility/aria-live';
+  import { isEtp2026Enabled } from '@Utility/config_utils.js';
 
   const i18n = $_;
   const { announceError, announceSuccess } =
@@ -263,7 +264,7 @@
       {#if Kayttajat.isLaatija(whoami)}
         <div
           class="mb-4 flex lg:flex-row flex-col lg:space-x-4 text-primary font-bold">
-          {#if config?.isEtp2026}
+          {#if isEtp2026Enabled(config)}
             <div class="flex flex-row my-auto">
               <Link
                 text={i18n('energiatodistus.luo2026')}
@@ -448,7 +449,7 @@
       </div>
     </Overlay>
     <!-- New ET2026 implementation -->
-    {#if config?.isEtp2026}
+    {#if isEtp2026Enabled(config)}
       <div class="flex flew-row mb-4 mr-4">
         <span class="material-icons">attachment</span>
         &nbsp;

--- a/etp-front/src/pages/footer/Footer.svelte
+++ b/etp-front/src/pages/footer/Footer.svelte
@@ -3,9 +3,10 @@
   import * as Locales from '@Language/locale-utils';
 
   import Link from '@Component/Link/Link';
+  import { isEtp2026Enabled } from '@Utility/config_utils.js';
 
   export let version;
-  export let isEtp2026 = false;
+  export let config;
 
   $: footerLogoPath = Locales.isSV($locale)
     ? 'images/YM_Varke_vaaka_sin_SV_RGB.png'
@@ -83,7 +84,7 @@
     <img class="h-32" src={footerLogoPath} alt="Varke" />
     <p>
       {version.version}
-      {#if isEtp2026}
+      {#if isEtp2026Enabled(config)}
         ETP 2026
       {/if}
     </p>

--- a/etp-front/src/pages/laatija/laatija-form.svelte
+++ b/etp-front/src/pages/laatija/laatija-form.svelte
@@ -25,6 +25,7 @@
   import * as LaatijaSchema from './schema';
 
   import { announcementsForModule } from '@Utility/announce';
+  import { isEtp2026Enabled } from '@Utility/config_utils.js';
 
   const i18n = $_;
   const i18nRoot = 'laatija';
@@ -68,7 +69,7 @@
     R.pluck('id'),
     R.filter(
       R.propSatisfies(
-        config?.isEtp2026 ? R.T : PatevyystasotUtils.isBasicPatevyystaso,
+        isEtp2026Enabled(config) ? R.T : PatevyystasotUtils.isBasicPatevyystaso,
         'id'
       )
     )

--- a/etp-front/src/pages/laatija/laatijat.svelte
+++ b/etp-front/src/pages/laatija/laatijat.svelte
@@ -31,6 +31,7 @@
   import Spinner from '@Component/Spinner/Spinner.svelte';
   import { announcementsForModule } from '@Utility/announce';
   import { announcePolitely } from '@Utility/aria-live';
+  import { isEtp2026Enabled } from '@/utils/config_utils.js';
 
   const i18n = $_;
   const i18nRoot = 'laatijat';
@@ -251,7 +252,7 @@
                 R.pluck('id'),
                 R.filter(
                   R.propSatisfies(
-                    config.isEtp2026
+                    isEtp2026Enabled(config)
                       ? R.T
                       : PatevyystasotUtils.isBasicPatevyystaso,
                     'id'

--- a/etp-front/src/utils/config_utils.js
+++ b/etp-front/src/utils/config_utils.js
@@ -3,3 +3,5 @@ import * as R from 'ramda';
 const PRODUCTION_ENV_NAME = 'prod';
 
 export const isProduction = envName => R.equals(envName, PRODUCTION_ENV_NAME);
+
+export const isEtp2026Enabled = config => R.propEq(true, 'isEtp2026', config);


### PR DESCRIPTION
Use utility function for accessing the feature flag for etp2026 in etp-front. Always make a component dependent on the whole config instead of being dependent on the flag only.