### PR TITLE
AE-2574: Add Perusparannuspassi functionality and localization updates

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/api/perusparannuspassi.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/api/perusparannuspassi.clj
@@ -11,7 +11,7 @@
   (throw (ex-info "Not implemented" {:type :not-implemented})))
 
 (def private-routes
-  ["/perusparannuspassit"
+  [["/perusparannuspassit"
    ["/2026"
     [""
      {:post {:summary    "Lisää energiatodistukselle perusparannuspassi"
@@ -55,4 +55,4 @@
                :responses  {200 {:body nil}
                             404 {:body common-schema/GeneralError}}
                :access     rooli-service/ppp-laatija?
-               :handler    not-implemented!}}]]])
+               :handler    not-implemented!}}]]]])

--- a/etp-front/src/language/fi.json
+++ b/etp-front/src/language/fi.json
@@ -556,6 +556,7 @@
       "undo": "Peruuta muutokset",
       "sign": "Allekirjoita",
       "copy": "Kopioi pohjaksi",
+      "add-ppp": "Lisää PPP",
       "preview": "Esikatsele",
       "download": "Lataa",
       "discard": "Hylkää",
@@ -1241,7 +1242,9 @@
       "tyojono-add-success": "Energiatodistus lisättiin työjonoon onnistuneesti",
       "tyojono-add-error": "Energiatodistuksen lisääminen työjonoon epäonnistui",
       "tyojono-remove-success": "Energiatodistus poistettiin työjonosta onnistuneesti",
-      "tyojono-remove-error": "Energiatodistuksen poistaminen työjonosta epäonnistui"
+      "tyojono-remove-error": "Energiatodistuksen poistaminen työjonosta epäonnistui",
+      "add-ppp-success": "Perusparannuspassi lisättiin onnistuneesti",
+      "add-ppp-error": "Perusparannuspassin lisääminen epäonnistui"
     },
     "muutoshistoria": {
       "not-found": "Energiatodistusta ei ole olemassa.",

--- a/etp-front/src/language/sv.json
+++ b/etp-front/src/language/sv.json
@@ -534,6 +534,7 @@
       "undo": "Återkalla ändringar",
       "sign": "Underteckna",
       "copy": "Kopiera som mall",
+      "add-ppp": "Lisää PPP (sv)",
       "preview": "Förhandsvisa",
       "download": "Ladda ner",
       "discard": "Förkasta",
@@ -1214,7 +1215,9 @@
       "tyojono-add-error": "Det gick inte att lägga till energicertifikat i arbetskön",
       "tyojono-remove-success": "Energicertifikatet togs bort från arbetskön",
       "tyojono-remove-error": "Det gick inte att ta bort energicertifikatet från arbetskön",
-      "invalid-laskutusosoite-id": "Används inte längre. Välj en faktureringsuppgift som är i kraft."
+      "invalid-laskutusosoite-id": "Används inte längre. Välj en faktureringsuppgift som är i kraft.",
+      "add-ppp-success": "Grundförbättringspass lades till",
+      "add-ppp-error": "Det gick inte att lägga till grundförbättringspass"
     },
     "signing": {
       "header": "Undertecknande",

--- a/etp-front/src/pages/energiatodistus/EnergiatodistusForm.svelte
+++ b/etp-front/src/pages/energiatodistus/EnergiatodistusForm.svelte
@@ -280,7 +280,7 @@
           <H1 text={title} />
 
           {#if version == 2026 && energiatodistus['perusparannuspassi-id'] && Maybe.isSome(energiatodistus['perusparannuspassi-id'])}
-          <!-- Just for local development, wip indicator -->
+            <!-- Just for local development, wip indicator -->
             <div class="mb-3">
               <H1 text="PPP - Lisätty" />
             </div>

--- a/etp-front/src/pages/energiatodistus/EnergiatodistusForm.svelte
+++ b/etp-front/src/pages/energiatodistus/EnergiatodistusForm.svelte
@@ -264,7 +264,6 @@
   {/if}
 
   <DirtyConfirmation {dirty} />
-
   <div class="w-full relative flex">
     <div class="flex-grow overflow-x-hidden">
       <form
@@ -279,6 +278,13 @@
         on:reset={reset}>
         <div class="w-full mt-3">
           <H1 text={title} />
+
+          {#if version == 2026 && energiatodistus['perusparannuspassi-id'] && Maybe.isSome(energiatodistus['perusparannuspassi-id'])}
+          <!-- Just for local development, wip indicator -->
+            <div class="mb-3">
+              <H1 text="PPP - Lisätty" />
+            </div>
+          {/if}
 
           {#if EtUtils.isSigned(energiatodistus)}
             <div class="mb-5">

--- a/etp-front/src/pages/energiatodistus/ToolBar/toolbar.svelte
+++ b/etp-front/src/pages/energiatodistus/ToolBar/toolbar.svelte
@@ -288,6 +288,30 @@
       <span class="text-2xl font-icon">file_copy</span>
     </button>
   {/if}
+  {#if id.isSome() && Kayttajat.isLaatija(whoami) && version === 2026 && et.isDraft(energiatodistus)}
+    <button
+      disabled={pendingExecution}
+      on:click={_ => {
+        if (pendingExecution) return;
+        pendingExecution = true;
+        Future.fork(
+          response => {
+            pendingExecution = false;
+            announceError(i18n('energiatodistus.messages.add-ppp-error'));
+          },
+          result => {
+            pendingExecution = false;
+            announceSuccess(i18n('energiatodistus.messages.add-ppp-success'));
+            // Optionally reload or redirect to show the added PPP
+            cancel();
+          },
+          api.addPerusparannuspassi(fetch, Maybe.get(id))
+        );
+      }}>
+      <span class="description">{i18n('energiatodistus.toolbar.add-ppp')}</span>
+      <span class="text-2xl font-icon">add_circle_outline</span>
+    </button>
+  {/if}
   {#if R.includes(Toolbar.module.preview, fields)}
     {#each pdfUrls as pdfUrl}
       {#each pdfUrl.toArray() as { href, lang }}

--- a/etp-front/src/pages/energiatodistus/energiatodistus-api.js
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-api.js
@@ -413,3 +413,25 @@ export const signPdfsUsingSystemSignature = (fetch, version, id) =>
       )
     )
   )();
+
+export const addPerusparannuspassi = R.curry((fetch, energiatodistusId) =>
+  R.compose(
+    Fetch.responseAsJson,
+    Future.encaseP(
+      Fetch.fetchWithMethod(
+        fetch,
+        'post',
+        '/api/private/perusparannuspassit/2026'
+      )
+    )
+  )({
+    'energiatodistus-id': energiatodistusId,
+    valid: false,
+    vaiheet: [
+      { 'vaihe-nro': 1, valid: false },
+      { 'vaihe-nro': 2, valid: false },
+      { 'vaihe-nro': 3, valid: false },
+      { 'vaihe-nro': 4, valid: false }
+    ]
+  })
+);


### PR DESCRIPTION
Lisätty perustoiminnallisuus PPP:n lisäyksellä luonnostilaiselle ET26:lle. En kokenut tarvetta laittaa featureflagin taakse sillä toiminnon näkyvyys on riippuvainen ET26-olemassaolosta. Lisätty myös devauksen ajaksi indikaattori PPP:n lisäyksestä, jatko kehityksenä sitten lomake kunnolla kuntoon.

Tiketin kohtaa "Perusparannuspassi korvaa energiatodistuksen kohdat “Toimenpide-ehdotukset e-luvun parantamiseksi" ja "Suosituksia rakennuksen käyttöön ja ylläpitoon”. Sisältö jää lukutilaan.", en vielä toteuttanut, sillä en kokenut järkeväksi laittaa näitä vanhojen EnergiatodistustForm-komponenttien sisälle, ET26-formiahan meillä ei vielä ole luotuna

Lisäksi PR:ssä korjattu bugi aiemmin toteutetussa REST-rajapinnassa, priva-reitti vaati tuplavektorin.