### PR TITLE
feature/AE-2582-include-ppp-id-in-hakutulos-csv

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus_csv.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus_csv.clj
@@ -11,7 +11,7 @@
 
 (def private-columns
   (concat
-   (for [k [:id :versio :tila-id :laatija-id :laatija-fullname
+   (for [k [:id :perusparannuspassi-id :versio :tila-id :laatija-id :laatija-fullname
             :allekirjoitusaika :voimassaolo-paattymisaika
             :laskutusaika :draft-visible-to-paakayttaja :bypass-validation-limits
             :bypass-validation-limits-reason :korvattu-energiatodistus-id

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_csv_test.clj
@@ -5,24 +5,45 @@
             [solita.etp.test-system :as ts]
             [solita.etp.test-data.laatija :as laatija-test-data]
             [solita.etp.test-data.energiatodistus :as energiatodistus-test-data]
-            [solita.etp.schema.energiatodistus :as schema]
+            [solita.etp.test-data.perusparannuspassi :as ppp-test-data]
             [solita.etp.service.complete-energiatodistus
              :as complete-energiatodistus-service]
             [solita.etp.service.energiatodistus-csv :as service]
+            [solita.etp.service.energiatodistus :as energiatodistus-service]
             [solita.etp.service.csv :as csv-service])
   (:import (java.time Instant)))
 
 (t/use-fixtures :each ts/fixture)
 
 (defn test-data-set []
-  (let [laatijat (laatija-test-data/generate-and-insert! 1)
-        energiatodistukset (energiatodistus-test-data/generate-and-insert!
-                            100
-                            2018
-                            true
-                            (-> laatijat keys sort first))]
-    {:laatijat laatijat
-     :energiatodistukset energiatodistukset}))
+  (let [laatijat-adds (laatija-test-data/generate-adds 1)
+        laatijat-ids (-> laatijat-adds
+                         first
+                         (assoc-in [:patevyystaso] 4)
+                         vector
+                         (laatija-test-data/insert!))
+        laatijat (zipmap laatijat-ids laatijat-adds)
+        laatija-id (first laatijat-ids)
+        laatija-whoami {:id laatija-id :patevyystaso 4 :rooli 0}
+        energiatodistukset-2018 (energiatodistus-test-data/generate-and-insert!
+                                  25
+                                  2018
+                                  true
+                                  laatija-id)
+        energiatodistukset-2026 (energiatodistus-test-data/generate-and-insert!
+                                  25
+                                  2026
+                                  true
+                                  laatija-id)
+        energiatodistukset (concat energiatodistukset-2018 energiatodistukset-2026)
+        ids-of-ets-with-pps (->> energiatodistukset-2026 keys (take 10))
+        ids-of-ets-without-pps (into [] (remove (-> ids-of-ets-with-pps set) (-> energiatodistukset keys set)))]
+    (ppp-test-data/generate-and-insert! ids-of-ets-with-pps laatija-whoami)
+    {:laatijat               laatijat
+     :ppp-laatija-whoami     laatija-whoami
+     :ids-of-ets-with-pps    ids-of-ets-with-pps
+     :ids-of-ets-without-pps ids-of-ets-without-pps
+     :energiatodistukset     energiatodistukset}))
 
 (t/deftest columns-test
   (let [luokittelut (complete-energiatodistus-service/luokittelut ts/*db*)]
@@ -37,8 +58,8 @@
     (t/is (every? #(contains? (set service/private-columns) %)
                   (->> (energiatodistus-test-data/generate-adds 100 2018 true)
                        (map #(complete-energiatodistus-service/complete-energiatodistus
-                              %
-                              luokittelut))
+                               %
+                               luokittelut))
                        (map #(dissoc % :kommentti :laskutusosoite-id))
                        (map #(xmap/dissoc-in % [:tulokset :kuukausierittely]))
                        (map #(xmap/dissoc-in % [:tulokset
@@ -55,22 +76,42 @@
 (t/deftest column-ks->str-test
   (t/is (= "" (service/column-ks->str [])))
   (t/is (= "Foo / B / 5 / X" (service/column-ks->str
-                              [:foo "b" 5 :x]))))
+                               [:foo "b" 5 :x]))))
 
 (t/deftest csv-line-test
   (t/is (= "\n" (csv-service/csv-line [])))
   (t/is (= "\"test\";1,235;-15;2021-01-01T14:15\n"
            (csv-service/csv-line ["test"
-                              1.23456
-                              -15
-                              (Instant/parse "2021-01-01T12:15:00.000Z")]))))
+                                  1.23456
+                                  -15
+                                  (Instant/parse "2021-01-01T12:15:00.000Z")]))))
 
 (t/deftest write-energiatodistukset-csv-test
-  (let [{:keys [laatijat energiatodistukset]} (test-data-set)
-        laatija-id (-> laatijat keys sort first)]
+  (let [{:keys [ids-of-ets-with-pps ids-of-ets-without-pps ppp-laatija-whoami]} (test-data-set)
+        laatija-id (:id ppp-laatija-whoami)]
     (let [result (service/energiatodistukset-private-csv
                    ts/*db* {:id laatija-id :rooli 0} {})
-          buffer (StringBuffer.)]
-      (result #(.append buffer %))
-      (t/is (str/starts-with? (.toString buffer)
-                              "\"Id\";\"Versio\";")))))
+          buffer (StringBuffer.)
+          _ (result #(.append buffer %))
+
+          et-with-ppp-id (rand-nth ids-of-ets-with-pps)
+          et-without-ppp-id (rand-nth ids-of-ets-without-pps)
+
+          csv-lines-strings (-> (.toString buffer) str/split-lines)
+          header-line (first csv-lines-strings)]
+      (t/testing "The csv starts with expected headers"
+        (t/is (str/starts-with? header-line
+                                "\"Id\";\"Perusparannuspassi-id\";\"Versio\";")))
+      (t/testing "Perusparannuspassi-id shows up as expected for a todistus with perusparannuspassi"
+        (let [et-with-ppp-line (->> csv-lines-strings
+                                    (filter #(str/starts-with? % (str et-with-ppp-id)))
+                                    first)
+              et-with-ppp (energiatodistus-service/find-energiatodistus ts/*db* et-with-ppp-id)
+              ppp-id (:perusparannuspassi-id et-with-ppp)]
+          (t/is (not (nil? ppp-id)))
+          (t/is (str/starts-with? et-with-ppp-line (str et-with-ppp-id ";" ppp-id ";")))))
+      (t/testing "Perusparannuspassi-id is empty for energiatodistus without perusparannuspassi"
+        (let [et-without-ppp-line (->> csv-lines-strings
+                                       (filter #(str/starts-with? % (str et-without-ppp-id)))
+                                       first)]
+          (t/is (str/starts-with? et-without-ppp-line (str et-without-ppp-id ";;"))))))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/test_data/energiatodistus.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/test_data/energiatodistus.clj
@@ -1,7 +1,5 @@
 (ns solita.etp.test-data.energiatodistus
   (:require [clojure.java.io :as io]
-            [clojure.string :as str]
-            [clojure.test.check.generators :as test-generators]
             [flathead.deep :as deep]
             [schema-generators.generators :as g]
             [schema.core :as schema]
@@ -20,16 +18,7 @@
            (java.io FileInputStream ObjectInputStream)
            (java.time Instant)))
 
-(defn not-escaped-backslash? [generated-string]
-  (not (str/includes? generated-string "\\")))
-
-(def string-generator
-  "Pure string-ascii generator can generate \\ which breaks test
-   when the generated string goes to PostgreSQL like search"
-  (test-generators/such-that not-escaped-backslash?
-                             test-generators/string-ascii))
-
-(def generators {schema/Str                   string-generator
+(def generators {schema/Str                   generators/postgresql-safe-string-generator
                  schema/Num                   (g/always 1.0M)
                  common-schema/Num1           (g/always 1.0M)
                  common-schema/NonNegative    (g/always 1.0M)

--- a/etp-core/etp-backend/src/test/clj/solita/etp/test_data/generators.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/test_data/generators.clj
@@ -1,5 +1,6 @@
 (ns solita.etp.test-data.generators
-  (:require [clojure.test.check.generators :as test-generators]
+  (:require [clojure.string :as str]
+            [clojure.test.check.generators :as test-generators]
             [schema-generators.generators :as g]
             [schema-generators.complete :as c]
             [solita.etp.schema.common :as common]
@@ -9,6 +10,15 @@
             [solita.etp.schema.kayttaja])
   (:import (java.time Instant LocalDate)
            (java.util UUID)))
+
+(defn not-escaped-backslash? [generated-string]
+  (not (str/includes? generated-string "\\")))
+
+(def postgresql-safe-string-generator
+  "Pure string-ascii generator can generate \\ which breaks test
+   when the generated string goes to PostgreSQL like search"
+  (test-generators/such-that not-escaped-backslash?
+                             test-generators/string-ascii))
 
 (defn unique-henkilotunnukset-f []
   (let [state (atom 0)]

--- a/etp-core/etp-backend/src/test/clj/solita/etp/test_data/perusparannuspassi.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/test_data/perusparannuspassi.clj
@@ -1,0 +1,59 @@
+(ns solita.etp.test-data.perusparannuspassi
+  (:require [schema-generators.generators :as g]
+            [clojure.test.check.generators :as test-generators]
+            [solita.etp.test-data.generators :as generators]
+            [solita.etp.test-system :as ts]
+            [solita.etp.schema.perusparannuspassi :as perusparannuspassi-schema]
+            [solita.etp.service.perusparannuspassi :as perusparannuspassi-service]))
+
+(def vaihe-nro-gen
+  (test-generators/choose 1 4))
+
+(def vaihe-gen
+  (test-generators/let [n vaihe-nro-gen
+                        v test-generators/boolean]
+                       {:vaihe-nro n
+                        :valid     v}))
+
+;; Generate 0..4 unique phases (distinct vaihe-nro, optional random order)
+(def vaiheet-gen
+  (test-generators/let [ns (g/always [1 2 3 4])
+                        bs (test-generators/vector test-generators/boolean (count ns))]
+                       (->> (map vector ns bs)
+                            (mapv (fn [[n b]] {:vaihe-nro n :valid b})))))
+
+(def perusparannuspassi-save-gen
+  "Generates a PerusparannupassiSave without energiatodistus-id."
+  (test-generators/let [valid (g/always true)
+                        vaiheet vaiheet-gen]
+    {:valid   valid
+     :vaiheet vaiheet}))
+
+(def generators {perusparannuspassi-schema/PerusparannuspassiSave perusparannuspassi-save-gen
+                 [perusparannuspassi-schema/PerusparannuspassiVaihe] vaiheet-gen})
+
+(defn generate-add
+  "Generates a perusparannuspassi that can be added.
+
+  Parameters:
+  - `energiatodistus-id` - ppp can only be created for an existing et"
+  [energiatodistus-id]
+  (generators/complete
+    {:energiatodistus-id energiatodistus-id}
+    perusparannuspassi-schema/PerusparannuspassiSave
+    generators))
+
+(defn generate-adds [energiatodistus-ids]
+  (map generate-add energiatodistus-ids))
+
+(defn insert! [perusparannuspassi-adds whoami]
+  (mapv #(:id (perusparannuspassi-service/insert-perusparannuspassi!
+               (ts/db-user (:id whoami))
+               whoami
+               %)) perusparannuspassi-adds))
+
+(defn generate-and-insert!
+  [energiatodistus-ids laatija-id]
+   (let [perusparannuspassi-adds (generate-adds energiatodistus-ids)]
+     (insert! perusparannuspassi-adds laatija-id)))
+


### PR DESCRIPTION
Makes the perusparannuspassi-id appear in the private-csv.
Also adds some testing utilities for perusparannuspassi.

There is no need to hide this behind a feature flag since downloading the csv is hidden from laatija before ETP2026.