### PR TITLE
AE-2582: Include the Perusparannuspassi-id column in the csv

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus_csv.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/energiatodistus_csv.clj
@@ -11,7 +11,7 @@
 
 (def private-columns
   (concat
-   (for [k [:id :versio :tila-id :laatija-id :laatija-fullname
+   (for [k [:id :perusparannuspassi-id :versio :tila-id :laatija-id :laatija-fullname
             :allekirjoitusaika :voimassaolo-paattymisaika
             :laskutusaika :draft-visible-to-paakayttaja :bypass-validation-limits
             :bypass-validation-limits-reason :korvattu-energiatodistus-id

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_csv_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_csv_test.clj
@@ -72,5 +72,12 @@
                    ts/*db* {:id laatija-id :rooli 0} {})
           buffer (StringBuffer.)]
       (result #(.append buffer %))
-      (t/is (str/starts-with? (.toString buffer)
-                              "\"Id\";\"Versio\";")))))
+      (t/testing "The csv starts with expected headers"
+        (t/is (str/starts-with? (.toString buffer)
+                                "\"Id\";\"Perusparannuspassi-id\";\"Versio\";")))
+      #_(t/testing "Perusparannuspassi-id shows up as expected for a todistus with perusparannuspassi"
+        ;;TODO: AE-2582: Finish once the testing kit is complete
+        (t/is false))
+      #_(t/testing "Perusparannuspassi-id is empty for energiatodistus without perusparannuspassi"
+        ;; TODO: AE-2582: Finish once the testing kit is complete
+        (t/is false)))))


### PR DESCRIPTION
There is no need to hide this behind a feature flag since downloading the csv is hidden from laatija before ETP2026.