### PR TITLE
AE-2590: Hakutoiminnon laajennus sisältämään myös perusparannuspasseihin kohdistuvia hakuehtoja

### DIFF
--- a/etp-core/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
@@ -1,12 +1,14 @@
 (ns solita.etp.energiatodistus-search-api-test
   (:require
     [clojure.test :as t]
+    [clojure.java.jdbc :as jdbc]
     [jsonista.core :as j]
     [ring.mock.request :as mock]
     [solita.etp.test-data.kayttaja :as test-kayttajat]
     [solita.etp.test-system :as ts]
     [solita.etp.test-data.energiatodistus :as energiatodistus-test-data]
     [solita.etp.test-data.laatija :as laatija-test-data]
+    [solita.etp.test-data.perusparannuspassi :as ppp-test-data]
     [solita.etp.service.energiatodistus-search-test :as energiatodistus-search-test]))
 
 (t/use-fixtures :each ts/fixture)
@@ -79,3 +81,52 @@
                                  (mock/header "Accept" "application/json")))]
     ;; Then: HTTP 400 error
     (t/is (= (:status response) 400))))
+
+;; AE-2590: API-level test for searching by perusparannuspassi.valid
+(t/deftest search-energiatodistus-by-ppp-valid-api-test
+  ;; Given: ET2026 certificates, some with PPP and some without
+  (let [[laatija-id] (laatija-test-data/insert!
+                       (map #(assoc-in % [:patevyystaso] 4)
+                            (laatija-test-data/generate-adds 1)))
+        laatija-whoami {:id laatija-id :patevyystaso 4 :rooli 0}]
+    (test-kayttajat/insert-virtu-paakayttaja!)
+    (let [et-with-ppp-adds (energiatodistus-test-data/generate-adds 1 2026 true)
+          et-without-ppp-adds (energiatodistus-test-data/generate-adds 1 2026 true)
+          ids-with-ppp (energiatodistus-test-data/insert! et-with-ppp-adds laatija-id)
+          ids-without-ppp (energiatodistus-test-data/insert! et-without-ppp-adds laatija-id)]
+      (energiatodistus-search-test/sign-energiatodistukset!
+        (map #(vector laatija-id %) (concat ids-with-ppp ids-without-ppp)))
+      (ppp-test-data/generate-and-insert! ids-with-ppp laatija-whoami)
+      ;; When: GET with where clause for perusparannuspassi.valid = true
+      ;; URL-encoded: [[["=","perusparannuspassi.valid",true]]]
+      (let [response (ts/handler (-> (mock/request :get "/api/private/energiatodistukset?where=%5B%5B%5B%22%3D%22%2C%22perusparannuspassi.valid%22%2Ctrue%5D%5D%5D")
+                                     (test-kayttajat/with-virtu-user)
+                                     (mock/header "Accept" "application/json")))
+            response-body (j/read-value (:body response) j/keyword-keys-object-mapper)]
+        ;; Then: HTTP 200 with only the certificate that has PPP
+        (t/is (= (:status response) 200))
+        (t/is (= (count response-body) 1))
+        (t/is (= (:id (first response-body)) (first ids-with-ppp)))))))
+
+;; AE-2590: API-level test for searching by yksinkertaistettu-paivitysmenettely
+(t/deftest search-energiatodistus-by-yksinkertaistettu-api-test
+  ;; Given: ET2026 certificates, one with yksinkertaistettu-paivitysmenettely = true
+  (let [[laatija-id] (laatija-test-data/insert! (laatija-test-data/generate-adds 1))]
+    (test-kayttajat/insert-virtu-paakayttaja!)
+    (let [et-adds (energiatodistus-test-data/generate-adds 2 2026 true)
+          ids (energiatodistus-test-data/insert! et-adds laatija-id)
+          target-id (first ids)]
+      (energiatodistus-search-test/sign-energiatodistukset! (map #(vector laatija-id %) ids))
+      ;; Set one to true
+      (jdbc/execute! ts/*db*
+        ["UPDATE energiatodistus SET yksinkertaistettu_paivitysmenettely = true WHERE id = ?" target-id])
+      ;; When: GET with where clause for yksinkertaistettu-paivitysmenettely = true
+      ;; URL-encoded: [[["=","energiatodistus.yksinkertaistettu-paivitysmenettely",true]]]
+      (let [response (ts/handler (-> (mock/request :get "/api/private/energiatodistukset?where=%5B%5B%5B%22%3D%22%2C%22energiatodistus.yksinkertaistettu-paivitysmenettely%22%2Ctrue%5D%5D%5D")
+                                     (test-kayttajat/with-virtu-user)
+                                     (mock/header "Accept" "application/json")))
+            response-body (j/read-value (:body response) j/keyword-keys-object-mapper)]
+        ;; Then: HTTP 200 with only the certificate that has true
+        (t/is (= (:status response) 200))
+        (t/is (= (count response-body) 1))
+        (t/is (= (:id (first response-body)) target-id))))))

--- a/etp-core/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/energiatodistus_search_api_test.clj
@@ -94,9 +94,10 @@
           et-without-ppp-adds (energiatodistus-test-data/generate-adds 1 2026 true)
           ids-with-ppp (energiatodistus-test-data/insert! et-with-ppp-adds laatija-id)
           ids-without-ppp (energiatodistus-test-data/insert! et-without-ppp-adds laatija-id)]
+      ;; Insert PPP before signing (PPP can only be added to draft ET)
+      (ppp-test-data/generate-and-insert! ids-with-ppp laatija-whoami)
       (energiatodistus-search-test/sign-energiatodistukset!
         (map #(vector laatija-id %) (concat ids-with-ppp ids-without-ppp)))
-      (ppp-test-data/generate-and-insert! ids-with-ppp laatija-whoami)
       ;; When: GET with where clause for perusparannuspassi.valid = true
       ;; URL-encoded: [[["=","perusparannuspassi.valid",true]]]
       (let [response (ts/handler (-> (mock/request :get "/api/private/energiatodistukset?where=%5B%5B%5B%22%3D%22%2C%22perusparannuspassi.valid%22%2Ctrue%5D%5D%5D")

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_search_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_search_test.clj
@@ -1657,7 +1657,9 @@
         energiatodistus-ids-without-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
         ;; Create 2 ET2026 with PPP
         energiatodistus-ids-with-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
-        _ (ppp-test-data/generate-and-insert! energiatodistus-ids-with-ppp laatija-whoami)]
+        _ (ppp-test-data/generate-and-insert! energiatodistus-ids-with-ppp laatija-whoami)
+        ;; Sign all ETs so they are visible to paakayttaja (tila-id = 2)
+        _ (sign-energiatodistukset! (map #(vec [laatija-id %]) (concat energiatodistus-ids-without-ppp energiatodistus-ids-with-ppp)))]
     ;; When: searching for perusparannuspassi.valid = true
     (let [results (search kayttaja-test-data/paakayttaja
                           [[["=" "perusparannuspassi.valid" true]]]
@@ -1680,7 +1682,9 @@
         energiatodistus-ids-without-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
         ;; Create 2 ET2026 with PPP
         energiatodistus-ids-with-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
-        _ (ppp-test-data/generate-and-insert! energiatodistus-ids-with-ppp laatija-whoami)]
+        _ (ppp-test-data/generate-and-insert! energiatodistus-ids-with-ppp laatija-whoami)
+        ;; Sign all ETs so they are visible to paakayttaja (tila-id = 2)
+        _ (sign-energiatodistukset! (map #(vec [laatija-id %]) (concat energiatodistus-ids-without-ppp energiatodistus-ids-with-ppp)))]
     ;; When: searching for perusparannuspassi.valid IS DISTINCT FROM true (= no valid PPP)
     (let [results (search kayttaja-test-data/paakayttaja
                           [[["is-distinct-from" "perusparannuspassi.valid" true]]]
@@ -1702,7 +1706,9 @@
         laatija-whoami {:id laatija-id :patevyystaso 4 :rooli 0}
         energiatodistus-ids (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
         ppp-ids (ppp-test-data/generate-and-insert! energiatodistus-ids laatija-whoami)
-        target-ppp-id (first ppp-ids)]
+        target-ppp-id (first ppp-ids)
+        ;; Sign all ETs so they are visible to paakayttaja (tila-id = 2)
+        _ (sign-energiatodistukset! (map #(vec [laatija-id %]) energiatodistus-ids))]
     ;; When: searching for perusparannuspassi.id = specific id
     (let [results (search kayttaja-test-data/paakayttaja
                           [[["=" "perusparannuspassi.id" target-ppp-id]]]

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_search_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/energiatodistus_search_test.clj
@@ -1589,3 +1589,128 @@
     ;; Then: ET2018 certificates appear (default false)
     (t/is (every? #(contains? result-ids %) et2018-ids)
            "ET2018 certificates should appear with default false for lammonjako-lampotilajousto")))
+
+;; AE-2590: Search by yksinkertaistettu-paivitysmenettely
+(t/deftest search-by-yksinkertaistettu-paivitysmenettely-true-test
+  ;; Given: ET2026 certificates where one has yksinkertaistettu-paivitysmenettely = true
+  (let [{:keys [energiatodistukset]} (test-data-set-2026)
+        [id-true id-false] (sort (keys energiatodistukset))]
+    ;; Set one certificate's yksinkertaistettu-paivitysmenettely to true via direct SQL
+    (jdbc/execute! ts/*db*
+      ["UPDATE energiatodistus SET yksinkertaistettu_paivitysmenettely = true WHERE id = ?" id-true])
+    ;; When: searching for yksinkertaistettu-paivitysmenettely = true
+    (let [results (search kayttaja-test-data/paakayttaja
+                          [[["="
+                             "energiatodistus.yksinkertaistettu-paivitysmenettely"
+                             true]]]
+                          nil nil nil)
+          result-ids (set (map :id results))]
+      ;; Then: only the certificate with true is returned
+      (t/is (contains? result-ids id-true)
+             "Certificate with yksinkertaistettu-paivitysmenettely true should be found")
+      (t/is (not (contains? result-ids id-false))
+             "Certificate with yksinkertaistettu-paivitysmenettely false should not be found"))))
+
+(t/deftest search-by-yksinkertaistettu-paivitysmenettely-false-test
+  ;; Given: ET2026 certificates where one has yksinkertaistettu-paivitysmenettely = true
+  (let [{:keys [energiatodistukset]} (test-data-set-2026)
+        [id-true id-false] (sort (keys energiatodistukset))]
+    (jdbc/execute! ts/*db*
+      ["UPDATE energiatodistus SET yksinkertaistettu_paivitysmenettely = true WHERE id = ?" id-true])
+    ;; When: searching for yksinkertaistettu-paivitysmenettely = false
+    (let [results (search kayttaja-test-data/paakayttaja
+                          [[["="
+                             "energiatodistus.yksinkertaistettu-paivitysmenettely"
+                             false]]]
+                          nil nil nil)
+          result-ids (set (map :id results))]
+      ;; Then: only the certificate with false is returned
+      (t/is (contains? result-ids id-false)
+             "Certificate with yksinkertaistettu-paivitysmenettely false should be found")
+      (t/is (not (contains? result-ids id-true))
+             "Certificate with yksinkertaistettu-paivitysmenettely true should not be found"))))
+
+(t/deftest search-by-yksinkertaistettu-paivitysmenettely-false-includes-et2018-test
+  ;; Given: ET2018 and ET2026 certificates (ET2018 have default false)
+  (let [{:keys [energiatodistukset-2018 energiatodistukset-2026]} (test-data-set-mixed)
+        et2018-ids (set (keys energiatodistukset-2018))
+        ;; When: searching = false
+        results (search kayttaja-test-data/paakayttaja
+                        [[["="
+                           "energiatodistus.yksinkertaistettu-paivitysmenettely"
+                           false]]]
+                        nil nil nil)
+        result-ids (set (map :id results))]
+    ;; Then: ET2018 certificates appear (default false)
+    (t/is (every? #(contains? result-ids %) et2018-ids)
+           "ET2018 certificates should appear with default false for yksinkertaistettu-paivitysmenettely")))
+
+;; AE-2590: Search by perusparannuspassi.valid filter (regression tests for existing behavior)
+(t/deftest search-by-ppp-valid-true-filter-test
+  ;; Given: ET2026 certificates, some with PPP and some without
+  (let [laatija-id (->> (laatija-test-data/generate-adds 1)
+                        (map #(assoc-in % [:patevyystaso] 4))
+                        (laatija-test-data/insert!)
+                        first)
+        laatija-whoami {:id laatija-id :patevyystaso 4 :rooli 0}
+        ;; Create 2 ET2026 without PPP
+        energiatodistus-ids-without-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
+        ;; Create 2 ET2026 with PPP
+        energiatodistus-ids-with-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
+        _ (ppp-test-data/generate-and-insert! energiatodistus-ids-with-ppp laatija-whoami)]
+    ;; When: searching for perusparannuspassi.valid = true
+    (let [results (search kayttaja-test-data/paakayttaja
+                          [[["=" "perusparannuspassi.valid" true]]]
+                          nil nil nil)
+          result-ids (set (map :id results))]
+      ;; Then: only certificates with valid PPP are returned
+      (t/is (every? #(contains? result-ids %) energiatodistus-ids-with-ppp)
+             "Certificates with PPP should be found")
+      (t/is (not-any? #(contains? result-ids %) energiatodistus-ids-without-ppp)
+             "Certificates without PPP should not be found"))))
+
+(t/deftest search-by-ppp-valid-is-distinct-from-filter-test
+  ;; Given: ET2026 certificates, some with PPP and some without
+  (let [laatija-id (->> (laatija-test-data/generate-adds 1)
+                        (map #(assoc-in % [:patevyystaso] 4))
+                        (laatija-test-data/insert!)
+                        first)
+        laatija-whoami {:id laatija-id :patevyystaso 4 :rooli 0}
+        ;; Create 2 ET2026 without PPP
+        energiatodistus-ids-without-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
+        ;; Create 2 ET2026 with PPP
+        energiatodistus-ids-with-ppp (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
+        _ (ppp-test-data/generate-and-insert! energiatodistus-ids-with-ppp laatija-whoami)]
+    ;; When: searching for perusparannuspassi.valid IS DISTINCT FROM true (= no valid PPP)
+    (let [results (search kayttaja-test-data/paakayttaja
+                          [[["is-distinct-from" "perusparannuspassi.valid" true]]]
+                          nil nil nil)
+          result-ids (set (map :id results))]
+      ;; Then: certificates WITHOUT PPP are returned
+      (t/is (every? #(contains? result-ids %) energiatodistus-ids-without-ppp)
+             "Certificates without PPP should be found")
+      ;; And: certificates WITH valid PPP are NOT returned
+      (t/is (not-any? #(contains? result-ids %) energiatodistus-ids-with-ppp)
+             "Certificates with valid PPP should not be found"))))
+
+(t/deftest search-by-ppp-id-filter-test
+  ;; Given: ET2026 certificates with known PPP ids
+  (let [laatija-id (->> (laatija-test-data/generate-adds 1)
+                        (map #(assoc-in % [:patevyystaso] 4))
+                        (laatija-test-data/insert!)
+                        first)
+        laatija-whoami {:id laatija-id :patevyystaso 4 :rooli 0}
+        energiatodistus-ids (keys (energiatodistus-test-data/generate-and-insert! 2 2026 true laatija-id))
+        ppp-ids (ppp-test-data/generate-and-insert! energiatodistus-ids laatija-whoami)
+        target-ppp-id (first ppp-ids)]
+    ;; When: searching for perusparannuspassi.id = specific id
+    (let [results (search kayttaja-test-data/paakayttaja
+                          [[["=" "perusparannuspassi.id" target-ppp-id]]]
+                          nil nil nil)
+          result-ids (set (map :id results))]
+      ;; Then: exactly one certificate is returned
+      (t/is (= 1 (count results))
+             "Exactly one certificate should match the specific PPP id")
+      ;; And: the result's perusparannuspassi-id matches
+      (t/is (= target-ppp-id (:perusparannuspassi-id (first results)))
+             "The returned certificate should have the matching PPP id"))))

--- a/etp-front/src/language/fi.json
+++ b/etp-front/src/language/fi.json
@@ -452,6 +452,7 @@
     "draft-visible-to-paakayttaja": "Valvojat saavat nähdä luonnostilaisen energiatodistuksen",
     "bypass-validation-limits": "Ohita tarkistukset allekirjoittaessa",
     "bypass-validation-limits-reason": "Selite tarkistusten ohittamisesta",
+    "yksinkertaistettu-paivitysmenettely": "Yksinkertaistettu päivitysmenettely",
     "haku": {
       "sarakkeet": {
         "tila": "Tila",

--- a/etp-front/src/language/sv.json
+++ b/etp-front/src/language/sv.json
@@ -430,6 +430,7 @@
     "draft-visible-to-paakayttaja": "Övervakarna får se energicertifikatet i utkaststatus",
     "bypass-validation-limits": "Förbigå kontroller vid underskrift",
     "bypass-validation-limits-reason": "Förklaring av förbigång av kontroll",
+    "yksinkertaistettu-paivitysmenettely": "Förenklat uppdateringsförfarande",
     "haku": {
       "sarakkeet": {
         "tila": "Status",

--- a/etp-front/src/language/sv.json
+++ b/etp-front/src/language/sv.json
@@ -430,7 +430,7 @@
     "draft-visible-to-paakayttaja": "Övervakarna får se energicertifikatet i utkaststatus",
     "bypass-validation-limits": "Förbigå kontroller vid underskrift",
     "bypass-validation-limits-reason": "Förklaring av förbigång av kontroll",
-    "yksinkertaistettu-paivitysmenettely": "Förenklat uppdateringsförfarande",
+    "yksinkertaistettu-paivitysmenettely": "Yksinkertaistettu päivitysmenettely (sv)",
     "haku": {
       "sarakkeet": {
         "tila": "Status",

--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/energiatodistus-haku.svelte
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/energiatodistus-haku.svelte
@@ -35,7 +35,11 @@
   let overlay = true;
   let schema = R.when(
     R.always(R.not(isEtp2026Enabled(config))),
-    R.omit(['perusparannuspassi.id', 'perusparannuspassi.valid', 'energiatodistus.yksinkertaistettu-paivitysmenettely'])
+    R.omit([
+      'perusparannuspassi.id',
+      'perusparannuspassi.valid',
+      'energiatodistus.yksinkertaistettu-paivitysmenettely'
+    ])
   )(
     Kayttajat.isPaakayttajaOrLaskuttaja(whoami)
       ? EtHakuSchema.paakayttajaSchema

--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/energiatodistus-haku.svelte
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/energiatodistus-haku.svelte
@@ -35,7 +35,7 @@
   let overlay = true;
   let schema = R.when(
     R.always(R.not(isEtp2026Enabled(config))),
-    R.omit(['perusparannuspassi.id', 'perusparannuspassi.valid'])
+    R.omit(['perusparannuspassi.id', 'perusparannuspassi.valid', 'energiatodistus.yksinkertaistettu-paivitysmenettely'])
   )(
     Kayttajat.isPaakayttajaOrLaskuttaja(whoami)
       ? EtHakuSchema.paakayttajaSchema

--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema.js
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema.js
@@ -773,7 +773,8 @@ export const schema = {
     'lisamerkintoja-fi': [stringContains],
     'lisamerkintoja-sv': [stringContains],
     laskuriviviite: [...stringComparisons],
-    'laatija-id': [laatijaEquals]
+    'laatija-id': [laatijaEquals],
+    'yksinkertaistettu-paivitysmenettely': [singleBoolean]
   },
   perusparannuspassi: {
     id: [...numberComparisons],

--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema_test.js
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema_test.js
@@ -573,8 +573,8 @@ describe('EtHakuSchema', () => {
         expect(filteredSchema).not.toHaveProperty(field);
       });
       // And: other fields are still present
-      expect(filteredSchema).toHaveProperty('energiatodistus.id');
-      expect(filteredSchema).toHaveProperty('energiatodistus.versio');
+      expect(filteredSchema).toHaveProperty(['energiatodistus.id']);
+      expect(filteredSchema).toHaveProperty(['energiatodistus.versio']);
     });
   });
 

--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema_test.js
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema_test.js
@@ -532,7 +532,9 @@ describe('EtHakuSchema', () => {
         false
       );
       // Then: uses is-distinct-from to include NULL (no PPP record) and false (deleted PPP)
-      expect(result).toEqual([['is-distinct-from', 'perusparannuspassi.valid', true]]);
+      expect(result).toEqual([
+        ['is-distinct-from', 'perusparannuspassi.valid', true]
+      ]);
     });
   });
 

--- a/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema_test.js
+++ b/etp-front/src/pages/energiatodistus/energiatodistus-haku/schema_test.js
@@ -228,6 +228,7 @@ describe('EtHakuSchema', () => {
         'energiatodistus.tulokset.uusiutuvan-energian-osuus',
         'energiatodistus.versio',
         'energiatodistus.voimassaolo-paattymisaika',
+        'energiatodistus.yksinkertaistettu-paivitysmenettely',
         'kunta.id',
         'laatija.voimassaolo-paattymisaika',
         'perusparannuspassi.id',
@@ -454,6 +455,7 @@ describe('EtHakuSchema', () => {
         'energiatodistus.tulokset.uusiutuvat-omavaraisenergiat.tuulisahko-neliovuosikulutus',
         'energiatodistus.versio',
         'energiatodistus.voimassaolo-paattymisaika',
+        'energiatodistus.yksinkertaistettu-paivitysmenettely',
         'kunta.id',
         'laatija.patevyystaso',
         'laatija.toteamispaivamaara',
@@ -463,6 +465,114 @@ describe('EtHakuSchema', () => {
         'postinumero.label'
       ];
       expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('yksinkertaistettu-paivitysmenettely search field', () => {
+    // AE-2590: yksinkertaistettu-paivitysmenettely should be a BOOLEAN field in the search schema
+    it('is a BOOLEAN type field in paakayttajaSchema', () => {
+      // Given: the paakayttajaSchema
+      const key = 'energiatodistus.yksinkertaistettu-paivitysmenettely';
+      // When: checking the field type
+      const field = Schema.paakayttajaSchema[key];
+      // Then: field exists and is BOOLEAN
+      expect(field).toBeDefined();
+      expect(field[0].type).toBe('BOOLEAN');
+    });
+
+    it('format does NOT inject a versio constraint', () => {
+      // Given: the yksinkertaistettu-paivitysmenettely field
+      const key = 'energiatodistus.yksinkertaistettu-paivitysmenettely';
+      const op = Schema.paakayttajaSchema[key][0];
+      // When: format is called with true and false
+      const resultTrue = op.operation.format(
+        op.operation.serverCommand,
+        op.key,
+        true
+      );
+      const resultFalse = op.operation.format(
+        op.operation.serverCommand,
+        op.key,
+        false
+      );
+      // Then: neither result contains a versio constraint
+      const hasVersioConstraint = result =>
+        result.some(
+          entry => Array.isArray(entry) && entry[1] === 'energiatodistus.versio'
+        );
+      expect(hasVersioConstraint(resultTrue)).toBe(false);
+      expect(hasVersioConstraint(resultFalse)).toBe(false);
+    });
+  });
+
+  describe('pppOlemassa filter', () => {
+    // AE-2590: Regression tests - verify existing PPP search filter behavior
+    it('format generates correct query for true (contains PPP)', () => {
+      // Given: the perusparannuspassi.valid field
+      const key = 'perusparannuspassi.valid';
+      const op = Schema.paakayttajaSchema[key][0];
+      // When: format is called with true
+      const result = op.operation.format(
+        op.operation.serverCommand,
+        op.key,
+        true
+      );
+      // Then: produces exact match on valid = true
+      expect(result).toEqual([['=', 'perusparannuspassi.valid', true]]);
+    });
+
+    it('format generates correct query for false (no PPP)', () => {
+      // Given: the perusparannuspassi.valid field
+      const key = 'perusparannuspassi.valid';
+      const op = Schema.paakayttajaSchema[key][0];
+      // When: format is called with false
+      const result = op.operation.format(
+        op.operation.serverCommand,
+        op.key,
+        false
+      );
+      // Then: uses is-distinct-from to include NULL (no PPP record) and false (deleted PPP)
+      expect(result).toEqual([['is-distinct-from', 'perusparannuspassi.valid', true]]);
+    });
+  });
+
+  describe('PPP-numero filter', () => {
+    // AE-2590: Regression tests - verify PPP id search field has numeric operators
+    it('perusparannuspassi.id has NUMBER type entries with expected operators', () => {
+      // Given: the perusparannuspassi.id field
+      const key = 'perusparannuspassi.id';
+      const field = Schema.paakayttajaSchema[key];
+      // When: checking operators
+      const browserCommands = field.map(f => f.operation.browserCommand);
+      // Then: has numeric comparison operators
+      expect(browserCommands).toContain('=');
+      expect(browserCommands).toContain('>');
+      expect(browserCommands).toContain('>=');
+      expect(browserCommands).toContain('<');
+      expect(browserCommands).toContain('<=');
+      // And: all entries are NUMBER type
+      expect(field.every(f => f.type === 'NUMBER')).toBe(true);
+    });
+  });
+
+  describe('ET2026 feature flag gating', () => {
+    // AE-2590: When ET2026 is disabled, PPP and yksinkertaistettu fields should be omittable
+    it('PPP and yksinkertaistettu-menettely fields can be omitted from schema', () => {
+      // Given: the full paakayttajaSchema
+      const fieldsToOmit = [
+        'perusparannuspassi.id',
+        'perusparannuspassi.valid',
+        'energiatodistus.yksinkertaistettu-paivitysmenettely'
+      ];
+      // When: omitting ET2026-specific fields (simulating isEtp2026Enabled = false)
+      const filteredSchema = R.omit(fieldsToOmit, Schema.paakayttajaSchema);
+      // Then: the omitted fields are not present
+      fieldsToOmit.forEach(field => {
+        expect(filteredSchema).not.toHaveProperty(field);
+      });
+      // And: other fields are still present
+      expect(filteredSchema).toHaveProperty('energiatodistus.id');
+      expect(filteredSchema).toHaveProperty('energiatodistus.versio');
     });
   });
 


### PR DESCRIPTION
Lähinnä lisätty yksinkertaisen menettelyn kenttä ja iso määrä testejä