### PR TITLE
AE-2825 Unescape filename in temp-file->liite

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/aineisto.clj
@@ -21,7 +21,7 @@
 
 (def find-aineistot luokittelu-service/find-aineistot)
 
-(defn set-access! [db kayttaja-id {:keys [aineisto-id valid-until ip-address]}]
+(defn ^:dynamic set-access! [db kayttaja-id {:keys [aineisto-id valid-until ip-address]}]
   (aineisto-db/insert-kayttaja-aineisto! db {:aineisto-id aineisto-id
                                              :kayttaja-id kayttaja-id
                                              :valid-until valid-until

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/liite.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/liite.clj
@@ -7,7 +7,8 @@
             [solita.etp.exception :as exception]
             [schema.coerce :as coerce]
             [clojure.java.jdbc :as jdbc]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [clojure.string :as string]))
 
 ; *** Require sql functions ***
 (db/require-queries 'liite)
@@ -31,11 +32,23 @@
               db whoami energiatodistus-id)
     (exception/throw-forbidden!)))
 
+(defn- unescape-quoted-string
+  "Multipart filenames are transmitted inside a quoted-string
+  (RFC 2616 section 2.2), where a backslash escapes the character that
+  follows it - for example, a literal quote character is sent as a
+  backslash followed by a quote. Ring's multipart parsing does not undo
+  this escaping, so any backslash followed by a character in the filename
+  needs to be unescaped back to that character before it is stored."
+  [s]
+  (when s
+    (string/replace s #"\\(.)" "$1")))
+
 (defn temp-file->liite [temp-file]
   (-> temp-file
       (dissoc :tempfile :size)
       (set/rename-keys {:content-type :contenttype
-                        :filename :nimi})))
+                        :filename :nimi})
+      (update :nimi unescape-quoted-string)))
 
 (defn add-liite-from-file! [db aws-s3-client energiatodistus-id file]
   (jdbc/with-db-transaction [db db]

--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/suomifi_viestit_rest.clj
@@ -114,10 +114,7 @@
                        :status  (:status response)
                        :response (:body response)})))))
 
-(defn send-suomifi-viesti-with-pdf-attachment!
-  [{:keys [external-id]
-    :as   message-info}
-   config]
+(defn ^:dynamic send-suomifi-viesti-with-pdf-attachment!
   "Sends a Suomi.fi-viesti that has the `pdf-file` as an attachment.
 
   The function expects a map containing the following keys:
@@ -135,7 +132,12 @@
   - :street-address string       - The recipient's street address.
   - :zip-code       string       - The recipient's zip code.
 
+  Marked ^:dynamic so tests can rebind this with a thread-local `binding`
+
   Returns: response"
+  [{:keys [external-id]
+    :as   message-info}
+   config]
   (log/info "Sending suomifi viesti with external-id: " external-id)
   (try
     (let [access-token (get-access-token! config)
@@ -157,13 +159,15 @@
                              :external-id external-id}
                         e))))))
 
-(defn validate-config [{:keys [rest-base-url
-                               palvelutunnus
-                               rest-password
-                               viranomaistunnus
-                               yhteyshenkilo-email
-                               laskutus-tunniste
-                               laskutus-salasana]}]
+(defn ^:dynamic validate-config
+  "Marked ^:dynamic so tests can rebind this with a thread-local `binding`"
+  [{:keys [rest-base-url
+           palvelutunnus
+           rest-password
+           viranomaistunnus
+           yhteyshenkilo-email
+           laskutus-tunniste
+           laskutus-salasana]}]
   (flatten
     [(if (str/blank? rest-base-url)
        ["rest-base-url is missing"]

--- a/etp-core/etp-backend/src/test/clj/solita/etp/api/energiatodistus_liite_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/api/energiatodistus_liite_test.clj
@@ -1,0 +1,85 @@
+(ns solita.etp.api.energiatodistus-liite-test
+  (:require [clojure.test :as t]
+            [clojure.java.io :as io]
+            [clojure.string :as string]
+            [jsonista.core :as j]
+            [ring.mock.request :as mock]
+            [solita.etp.test-data.kayttaja :as kayttaja-test-data]
+            [solita.etp.test-data.laatija :as laatija-test-data]
+            [solita.etp.test-data.energiatodistus :as energiatodistus-test-data]
+            [solita.etp.test-system :as ts]))
+
+(t/use-fixtures :each ts/fixture)
+
+(defn- fix-multipart-charset
+  "ring.mock.request/multipart-body sets Content-Type to
+  \"multipart/form-data; charset=...; boundary=...\". muuntaja's naive
+  content-type parser only looks at the first `;`-separated parameter and
+  assumes it's the charset with nothing following it, so it ends up trying
+  to negotiate the bogus charset \"iso-8859-1; boundary=...\" and fails.
+  Dropping the charset parameter (boundary is all reitit's multipart
+  middleware needs) avoids that and lets muuntaja fall back to its default."
+  [request]
+  (let [strip-charset #(string/replace % #";\s*charset=[^;]*" "")]
+    (-> request
+        (update :content-type strip-charset)
+        (update-in [:headers "content-type"] strip-charset))))
+
+(defn- post-liite-file! [energiatodistus-id filename]
+  (ts/handler (-> (mock/request :post (str "/api/private/energiatodistukset/2013/"
+                                            energiatodistus-id "/liitteet/files"))
+                  (kayttaja-test-data/with-virtu-user)
+                  (mock/header "Accept" "application/json")
+                  (mock/multipart-body
+                    {:files {:value        (io/file "deps.edn")
+                             :filename     filename
+                             :content-type "application/octet-stream"}})
+                  (fix-multipart-charset))))
+
+(defn- get-liitteet [energiatodistus-id]
+  (ts/handler (-> (mock/request :get (str "/api/private/energiatodistukset/2013/"
+                                          energiatodistus-id "/liitteet"))
+                  (kayttaja-test-data/with-virtu-user)
+                  (mock/header "Accept" "application/json"))))
+
+(defn- setup-energiatodistus-visible-to-paakayttaja! []
+  (kayttaja-test-data/insert-virtu-paakayttaja!)
+  (let [laatijat (laatija-test-data/generate-and-insert! 1)
+        laatija-id (-> laatijat keys sort first)
+        ;; POST /liitteet/files requires paakayttaja access, and paakayttaja
+        ;; can only see draft energiatodistukset marked visible to them.
+        add (-> (energiatodistus-test-data/generate-add 2013 true)
+                (assoc :draft-visible-to-paakayttaja true))]
+    (first (energiatodistus-test-data/insert! [add] laatija-id))))
+
+(t/deftest add-liite-with-empty-filename-test
+  (let [energiatodistus-id (setup-energiatodistus-visible-to-paakayttaja!)
+        post-response (post-liite-file! energiatodistus-id "")]
+    (t/is (= 201 (:status post-response))
+          "Attachment upload is accepted even with an empty filename")
+    (let [liitteet (-> (get-liitteet energiatodistus-id)
+                       :body
+                       (j/read-value j/keyword-keys-object-mapper))]
+      (t/is (some #(= "" (:nimi %)) liitteet)
+            "Empty filename is stored as-is"))))
+
+(t/deftest add-liite-with-quote-in-filename-test
+  (let [energiatodistus-id (setup-energiatodistus-visible-to-paakayttaja!)
+        filename "quote\"file.txt"
+        ;; The multipart encoder backslash-escapes the embedded quote in the
+        ;; Content-Disposition header (`filename="quote\"file.txt"`), and
+        ;; ring's multipart-params parsing does not undo that escaping, so
+        ;; the backslash ends up baked into the stored nimi. This is not
+        ;; app-level sanitization - it's just how the raw header value comes
+        ;; through - and it demonstrates that a quote character isn't
+        ;; rejected or stripped anywhere along the way.
+        expected-stored-filename "quote\\\"file.txt"
+        post-response (post-liite-file! energiatodistus-id filename)]
+    (t/is (= 201 (:status post-response))
+          "Attachment upload is accepted even with a quote in the filename")
+    (let [liitteet (-> (get-liitteet energiatodistus-id)
+                       :body
+                       (j/read-value j/keyword-keys-object-mapper))]
+      (t/is (some #(= expected-stored-filename (:nimi %)) liitteet)
+            "Filename containing a quote passes through without being rejected"))))
+

--- a/etp-core/etp-backend/src/test/clj/solita/etp/api/energiatodistus_liite_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/api/energiatodistus_liite_test.clj
@@ -4,10 +4,12 @@
             [clojure.string :as string]
             [jsonista.core :as j]
             [ring.mock.request :as mock]
+            [solita.etp.service.liite :as liite-service]
             [solita.etp.test-data.kayttaja :as kayttaja-test-data]
             [solita.etp.test-data.laatija :as laatija-test-data]
             [solita.etp.test-data.energiatodistus :as energiatodistus-test-data]
-            [solita.etp.test-system :as ts]))
+            [solita.etp.test-system :as ts])
+  (:import (java.nio.charset StandardCharsets)))
 
 (t/use-fixtures :each ts/fixture)
 
@@ -25,16 +27,16 @@
         (update :content-type strip-charset)
         (update-in [:headers "content-type"] strip-charset))))
 
-(defn- post-liite-file! [energiatodistus-id filename]
-  (ts/handler (-> (mock/request :post (str "/api/private/energiatodistukset/2013/"
-                                            energiatodistus-id "/liitteet/files"))
-                  (kayttaja-test-data/with-virtu-user)
-                  (mock/header "Accept" "application/json")
-                  (mock/multipart-body
-                    {:files {:value        (io/file "deps.edn")
-                             :filename     filename
-                             :content-type "application/octet-stream"}})
-                  (fix-multipart-charset))))
+(defn- post-liite-file [energiatodistus-id filename]
+  (-> (mock/request :post (str "/api/private/energiatodistukset/2013/"
+                             energiatodistus-id "/liitteet/files"))
+    (kayttaja-test-data/with-virtu-user)
+    (mock/header "Accept" "application/json")
+    (mock/multipart-body
+                  {:files {:value        (io/file "deps.edn")
+                           :filename     filename
+                           :content-type "application/octet-stream"}})
+    (fix-multipart-charset)))
 
 (defn- get-liitteet [energiatodistus-id]
   (ts/handler (-> (mock/request :get (str "/api/private/energiatodistukset/2013/"
@@ -50,11 +52,12 @@
         ;; can only see draft energiatodistukset marked visible to them.
         add (-> (energiatodistus-test-data/generate-add 2013 true)
                 (assoc :draft-visible-to-paakayttaja true))]
-    (first (energiatodistus-test-data/insert! [add] laatija-id))))
+    {:energiatodistus-id (first (energiatodistus-test-data/insert! [add] laatija-id))
+     :laatija-id laatija-id}))
 
 (t/deftest add-liite-with-empty-filename-test
-  (let [energiatodistus-id (setup-energiatodistus-visible-to-paakayttaja!)
-        post-response (post-liite-file! energiatodistus-id "")]
+  (let [{:keys [energiatodistus-id]} (setup-energiatodistus-visible-to-paakayttaja!)
+        post-response (ts/handler (post-liite-file energiatodistus-id ""))]
     (t/is (= 201 (:status post-response))
           "Attachment upload is accepted even with an empty filename")
     (let [liitteet (-> (get-liitteet energiatodistus-id)
@@ -63,23 +66,38 @@
       (t/is (some #(= "" (:nimi %)) liitteet)
             "Empty filename is stored as-is"))))
 
+(defn bais->str
+  "Reads all bytes from a ByteArrayInputStream, decodes as UTF-8,
+   resets the stream, and returns the string."
+  [^java.io.ByteArrayInputStream bais]
+  (.reset bais)
+  (let [bytes (.readAllBytes bais)]
+    (.reset bais)
+    (String. bytes StandardCharsets/UTF_8)))
+
 (t/deftest add-liite-with-quote-in-filename-test
-  (let [energiatodistus-id (setup-energiatodistus-visible-to-paakayttaja!)
+  (let [{:keys [energiatodistus-id laatija-id]} (setup-energiatodistus-visible-to-paakayttaja!)
         filename "quote\"file.txt"
-        ;; The multipart encoder backslash-escapes the embedded quote in the
-        ;; Content-Disposition header (`filename="quote\"file.txt"`), and
-        ;; ring's multipart-params parsing does not undo that escaping, so
-        ;; the backslash ends up baked into the stored nimi. This is not
-        ;; app-level sanitization - it's just how the raw header value comes
-        ;; through - and it demonstrates that a quote character isn't
-        ;; rejected or stripped anywhere along the way.
-        expected-stored-filename "quote\\\"file.txt"
-        post-response (post-liite-file! energiatodistus-id filename)]
+        escaped-filename "quote\\\"file.txt"
+        post-request (post-liite-file energiatodistus-id filename)
+        post-response (ts/handler post-request)]
     (t/is (= 201 (:status post-response))
           "Attachment upload is accepted even with a quote in the filename")
+
+    (t/is (string/includes?
+            (-> post-request :body bais->str)
+            escaped-filename)
+          "Expecting the quote to be escaped in the multipart request")
+
+    (let [liitteet-in-db (liite-service/find-energiatodistus-liitteet ts/*db*
+                                                                      {:id laatija-id :rooli 0}
+                                                                      energiatodistus-id)]
+      (t/is (= filename (-> liitteet-in-db first :nimi))
+            "Expecting the database to have filename in original form"))
+
     (let [liitteet (-> (get-liitteet energiatodistus-id)
                        :body
                        (j/read-value j/keyword-keys-object-mapper))]
-      (t/is (some #(= expected-stored-filename (:nimi %)) liitteet)
-            "Filename containing a quote passes through without being rejected"))))
+      (t/is (some #(= filename (:nimi %)) liitteet)
+            "Expecting deserialized filename to not be escaped"))))
 

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/aineisto_test.clj
@@ -23,7 +23,7 @@
 (t/deftest set-kayttaja-aineistot!-test
   (t/testing "Maximum of ten aineistot is allowed"
     ;; Mock the actual database inserts as they are not necessary for these tests
-    (with-redefs [aineisto/set-access! (fn [_ _ _] true)]
+    (binding [aineisto/set-access! (fn [_ _ _] true)]
       (t/testing "11 results in an exception"
         (t/is (thrown? Exception (aineisto/set-kayttaja-aineistot! ts/*db* 1 (take 11 test-aineisto)))))
       (t/testing "10 is allowed, return value 1 tells inserts succeeded"

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/liite_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/liite_test.clj
@@ -1,5 +1,6 @@
 (ns solita.etp.service.liite-test
   (:require [clojure.test :as t]
+            [clojure.java.io :as io]
             [solita.etp.test-system :as ts]
             [solita.etp.test :as etp-test]
             [solita.etp.test-data.laatija :as laatija-test-data]
@@ -117,6 +118,34 @@
                    ts/*db*
                    original-laatija-whoami
                    energiatodistus-id)))))))
+
+(t/deftest add-liitteet-with-unusual-filenames-test
+  (t/testing "Attachments with an empty filename or a filename containing a quote are accepted as-is"
+    (let [laatijat (laatija-test-data/generate-and-insert! 1)
+          laatija-id (-> laatijat keys sort first)
+          energiatodistukset (energiatodistus-test-data/generate-and-insert!
+                              1 2013 true laatija-id)
+          energiatodistus-id (-> energiatodistukset keys sort first)
+          whoami {:id laatija-id :rooli 0}
+          file-adds [{:size        100
+                      :tempfile    (io/file "deps.edn")
+                      :contenttype "application/octet-stream"
+                      :nimi        ""}
+                     {:size        100
+                      :tempfile    (io/file "Dockerfile")
+                      :contenttype "application/octet-stream"
+                      :nimi        "quote\"file.txt"}]
+          ids (service/add-liitteet-from-files! (ts/db-user laatija-id)
+                                                ts/*aws-s3-client*
+                                                whoami
+                                                energiatodistus-id
+                                                file-adds)
+          found (service/find-energiatodistus-liitteet
+                 ts/*db* whoami energiatodistus-id)
+          nimi-by-id (into {} (map (juxt :id :nimi) found))
+          [empty-nimi-id quote-nimi-id] ids]
+      (t/is (= "" (get nimi-by-id empty-nimi-id)))
+      (t/is (= "quote\"file.txt" (get nimi-by-id quote-nimi-id))))))
 
 (t/deftest find-liite-other-user
   (let [{:keys [laatijat energiatodistukset

--- a/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/valvonta_kaytto/valvonta_test.clj
@@ -37,8 +37,8 @@
                                                       "Vi uppmanar dig att besvara begäran om information senast den 10.11.2024.")
                                                  (:body message)))
                                         (deliver suomifi-message-sent true))]
-      (with-redefs [suomifi-viestit-rest/validate-config (fn [_] nil)
-                    suomifi-viestit-rest/send-suomifi-viesti-with-pdf-attachment! assert-suomifi-message-sent]
+      (binding [suomifi-viestit-rest/validate-config (fn [_] nil)
+                suomifi-viestit-rest/send-suomifi-viesti-with-pdf-attachment! assert-suomifi-message-sent]
         (let [kayttaja-id (test-kayttajat/insert-virtu-paakayttaja!)
               valvonta-id (valvonta-service/add-valvonta! ts/*db*
                                                           (-> {} (generators/complete valvonta-schema/ValvontaSave)


### PR DESCRIPTION
ETP does not use the filename itself, but this way things
stay consistent also for filenames that contain characters
that require escaping.