### PR TITLE
Revert "Recover from a bad content-length in ASHA response"

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/asha.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/asha.clj
@@ -1,18 +1,16 @@
 (ns solita.etp.service.asha
-  (:require [clj-http.client :as http]
+  (:require [clostache.parser :as clostache]
             [clj-http.conn-mgr :as conn-mgr]
-            [clojure.string :as str]
-            [clojure.tools.logging :as log]
-            [clostache.parser :as clostache]
-            [schema-tools.coerce :as sc]
+            [solita.etp.schema.asha :as asha-schema]
+            [clj-http.client :as http]
             [solita.common.xml :as xml]
+            [schema-tools.coerce :as sc]
+            [clojure.tools.logging :as log]
             [solita.etp.config :as config]
-            [solita.etp.schema.asha :as asha-schema])
-  (:import (java.io ByteArrayOutputStream InputStream)
-           (java.nio.charset StandardCharsets)
+            [clojure.string :as str])
+  (:import (java.nio.charset StandardCharsets)
            (java.time Instant)
-           (java.util Base64)
-           (org.apache.http ConnectionClosedException)))
+           (java.util Base64)))
 
 (def toplevel-processing-actions
   "Asha päätoimenpiteet etp is using. Not all of these are created by etp,
@@ -46,53 +44,16 @@
 (defn response->xml [response]
   (-> response xml/string->xml xml/without-soap-envelope first xml/with-kebab-case-tags))
 
-(defn- read-body-leniently
-  "Reads an InputStream fully into a UTF-8 string. ASHA (or something in
-   front of it) occasionally closes the connection a handful of bytes short
-   of the Content-Length it declared, which makes clj-http/Apache HttpClient
-   blow up with a ConnectionClosedException even though the body we did
-   receive is otherwise complete and usable. Instead of failing the whole
-   request in that case, log a warning and return whatever bytes were
-   actually received."
-  [^InputStream in expected-length]
-  (when-not (nil? in)
-    (let [buffer (byte-array 4096)
-          out (ByteArrayOutputStream.)]
-      (try
-        (loop []
-          (let [n (.read in buffer)]
-            (when (pos? n)
-              (.write out buffer 0 n)
-              (recur))))
-        (catch ConnectionClosedException e
-          (log/warn e (str "ASHA response body ended prematurely"
-                            (when expected-length
-                              (str " (expected " expected-length
-                                   " bytes, received " (.size out) ")"))
-                            "; using the partially received body.")))
-        (finally
-          (try
-            ;; In at least some versions of org.apache.http the
-            ;; org.apache.http.impl.io.ContentLengthInputStream.close() method
-            ;; attempts to drain more data from the underlying input stream using read(),
-            ;; which can then throw ConnectionClosedException again
-            (.close in)
-            (catch ConnectionClosedException _ nil))))
-      (String. (.toByteArray out) StandardCharsets/UTF_8))))
-
 (defn- ^:dynamic post! [request]
   (log/debug request)
   (if config/asha-endpoint-url
-    (let [response (http/post config/asha-endpoint-url
-                              (cond-> {:content-type     "application/xop+xml;charset=\"UTF-8\"; type=\"text/xml\""
-                                       :throw-exceptions false
-                                       :as               :stream
-                                       :body             request}
-                                      config/asha-proxy? (assoc
-                                                           :connection-manager
-                                                           (conn-mgr/make-socks-proxied-conn-manager "localhost" 1080))))
-          expected-length (some-> response :headers (get "content-length") parse-long)]
-      (update response :body read-body-leniently expected-length))
+    (http/post config/asha-endpoint-url
+               (cond-> {:content-type     "application/xop+xml;charset=\"UTF-8\"; type=\"text/xml\""
+                        :throw-exceptions false
+                        :body             request}
+                       config/asha-proxy? (assoc
+                                            :connection-manager
+                                            (conn-mgr/make-socks-proxied-conn-manager "localhost" 1080))))
     (do
       (log/info "Missing asha endpoint url. Skip request to asha...")
       {:status 200})))


### PR DESCRIPTION
dfb4d8aea9209ad9d87881adda38c9da2c0f224a
0ec12732d2053b53a71e28532ef552c4bfff322f
045c95319df0fceb9157c1baf9c0048e77e87f59