### PR TITLE
AE-2821 Fix login loop

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/handler.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/handler.clj
@@ -99,12 +99,6 @@
     (catch Throwable t
       (log/warn t "Failed to stamp logged_out_at on logout"))))
 
-(def empty-cookie {:value     ""
-                   :path      "/"
-                   :max-age   0
-                   :http-only true
-                   :secure    true})
-
 (def system-routes
   [["/openapi.json"
     {:get {:no-doc  true
@@ -141,8 +135,7 @@
                          (stamp-logout-if-identifiable! db req)
                          {:status  302
                           :headers {"Location" (logout-location req)}
-                          :cookies {"AWSELBAuthSessionCookie-0" empty-cookie
-                                    "AWSELBAuthSessionCookie-1" empty-cookie}})}}]
+                          :cookies security/clear-elb-cookies})}}]
    ;; TODO Temporary endpoint for seeing headers added by load balancer
    ["/headers"
     {:get {:summary "Endpoint for seeing request headers"
@@ -164,6 +157,7 @@
              (tag "Tilastointi Public API"
                   statistics-api/routes))]
     ["/private" {:middleware [[header-middleware/wrap-disable-cache]
+                              [cookies/wrap-cookies]
                               [security/wrap-jwt-payloads]
                               [security/wrap-whoami-from-jwt-payloads]
                               [security/wrap-reject-if-logged-out]

--- a/etp-core/etp-backend/src/main/clj/solita/etp/handler.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/handler.clj
@@ -14,7 +14,6 @@
             [reitit.ring.middleware.parameters :as parameters]
             [reitit.spec :as rs]
             [reitit.swagger-ui :as swagger-ui]
-            [ring.middleware.cookies :as cookies]
             [schema.coerce]
             [schema.core]
             [solita.etp.api.public-csv :as public-csv-api]
@@ -129,13 +128,12 @@
            :parameters {:query
                         {(s/optional-key :redirect-location) String}}
            :tags       #{"System"}
-           :middleware [[cookies/wrap-cookies]
-                        [security/wrap-db-application-name]]
+           :middleware [[security/wrap-db-application-name]]
            :handler    (fn [{:keys [db] :as req}]
                          (stamp-logout-if-identifiable! db req)
                          {:status  302
-                          :headers {"Location" (logout-location req)}
-                          :cookies security/clear-elb-cookies})}}]
+                          :headers (merge {"Location" (logout-location req)}
+                                          security/clear-elb-cookies-headers)})}}]
    ;; TODO Temporary endpoint for seeing headers added by load balancer
    ["/headers"
     {:get {:summary "Endpoint for seeing request headers"
@@ -157,7 +155,6 @@
              (tag "Tilastointi Public API"
                   statistics-api/routes))]
     ["/private" {:middleware [[header-middleware/wrap-disable-cache]
-                              [cookies/wrap-cookies]
                               [security/wrap-jwt-payloads]
                               [security/wrap-whoami-from-jwt-payloads]
                               [security/wrap-reject-if-logged-out]

--- a/etp-core/etp-backend/src/main/clj/solita/etp/security.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/security.clj
@@ -23,6 +23,15 @@
                  (str "Invalid JWT in service request: " (exception/service-name request) ".")
                  (maybe/fold "" #(format "Exception: %s." %) (dissoc (ex-data t) :message))))))
 
+(def empty-cookie {:value     ""
+                   :path      "/"
+                   :max-age   0
+                   :http-only true
+                   :secure    true})
+
+(def clear-elb-cookies {"AWSELBAuthSessionCookie-0" empty-cookie
+                        "AWSELBAuthSessionCookie-1" empty-cookie})
+
 (defn wrap-jwt-payloads [handler]
   (fn [req]
     (if-let [jwt (req->jwt req)]
@@ -144,7 +153,7 @@
   (fn [{:keys [jwt-payloads logged-out-at] :as req}]
     (let [auth-time (-> jwt-payloads :access :auth_time (Instant/ofEpochSecond))]
       (if (logged-out? auth-time logged-out-at)
-        response/unauthorized
+        (assoc response/unauthorized :cookies clear-elb-cookies)
         (handler req)))))
 
 (defn- sanitized-path [path]

--- a/etp-core/etp-backend/src/main/clj/solita/etp/security.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/security.clj
@@ -23,14 +23,9 @@
                  (str "Invalid JWT in service request: " (exception/service-name request) ".")
                  (maybe/fold "" #(format "Exception: %s." %) (dissoc (ex-data t) :message))))))
 
-(def empty-cookie {:value     ""
-                   :path      "/"
-                   :max-age   0
-                   :http-only true
-                   :secure    true})
-
-(def clear-elb-cookies {"AWSELBAuthSessionCookie-0" empty-cookie
-                        "AWSELBAuthSessionCookie-1" empty-cookie})
+(def clear-elb-cookies-headers
+  {"Set-Cookie" ["AWSELBAuthSessionCookie-0=; Path=/; Max-Age=0; HttpOnly; Secure"
+                 "AWSELBAuthSessionCookie-1=; Path=/; Max-Age=0; HttpOnly; Secure"]})
 
 (defn wrap-jwt-payloads [handler]
   (fn [req]
@@ -153,7 +148,7 @@
   (fn [{:keys [jwt-payloads logged-out-at] :as req}]
     (let [auth-time (-> jwt-payloads :access :auth_time (Instant/ofEpochSecond))]
       (if (logged-out? auth-time logged-out-at)
-        (assoc response/unauthorized :cookies clear-elb-cookies)
+        (assoc response/unauthorized :headers clear-elb-cookies-headers)
         (handler req)))))
 
 (defn- sanitized-path [path]

--- a/etp-core/etp-backend/src/test/clj/solita/etp/handler_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/handler_test.clj
@@ -55,8 +55,10 @@
     (let [response (ts/handler (logout-request))]
       (t/is (= 302 (:status response)))))
 
-  (t/testing "replaying the same (now revoked) JWT against a private endpoint is rejected with 401"
-    (t/is (= 401 (:status (ts/handler (whoami-request)))))))
+  (t/testing "replaying the same (now revoked) JWT is rejected with 401 and clears ALB session cookies"
+    (let [response (ts/handler (whoami-request))]
+      (t/is (= 401 (:status response)))
+      (t/is (true? (cleared-session-cookies? response))))))
 
 (t/deftest public-routes-are-unaffected-by-logout-test
   (let [response (ts/handler (mock/request :get "/api/public/kunnat"))]

--- a/etp-core/etp-backend/src/test/clj/solita/etp/security_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/security_test.clj
@@ -101,7 +101,7 @@
             req {:jwt-payloads {:access {:auth_time (.getEpochSecond auth-time)}}
                  :logged-out-at logged-out-at}
             response ((security/wrap-reject-if-logged-out spy-handler) req)]
-        (t/is (= response/unauthorized response))
+        (t/is (= 401 (-> response :status)))
         (t/is (false? @called?))))
 
     (t/testing "does not throw for well-formed requests where whoami-derived pieces are otherwise minimal"


### PR DESCRIPTION
This could happen in case a different session of the same user is logged out. As long as the immediate ELB auth session cookies are valid, the frontend would keep bouncing between the succeeding login endpoint and the unauthorized whoami endpoint.

The fix here is to clear the auth session cookies when the session is rejected due to logout stamp.