### PR TITLE
AE-2843 Add workaround for Content-Encoding: binary

### DIFF
--- a/etp-core/etp-backend/src/main/clj/solita/etp/service/signing/pdf_sign.clj
+++ b/etp-core/etp-backend/src/main/clj/solita/etp/service/signing/pdf_sign.clj
@@ -77,6 +77,13 @@
                              ^List (doto (ArrayList.) (.add (:certificate tsp-key-and-cert))))
     (.setTsaPolicy "1.2.3.4")))
 
+;; The DVV test service responds with Content-Encoding: binary, which HttpClient 5.6 rejects.
+(defn- data-loader-with-disabled-content-compression []
+  (proxy [CommonsDataLoader] []
+    (getHttpClientBuilder [url]
+      (doto (proxy-super getHttpClientBuilder url)
+        (.disableContentCompression)))))
+
 ;; We add the root certificate as trusted in order to trust the timestamping service's SSL certificate.
 (defn get-data-loader-for-https []
   (let [cert-token (pem->CertificateToken config/dvv-timestamp-service-root-cert)
@@ -87,7 +94,7 @@
         key-store-document (with-open [baos (ByteArrayOutputStream.)]
                              (-> key-store (.store baos password))
                              (InMemoryDocument. (ByteArrayInputStream. (.toByteArray baos))))]
-    (doto (CommonsDataLoader.)
+    (doto (data-loader-with-disabled-content-compression)
       (.setSslTruststorePassword password)
       (.setSslTruststore key-store-document))))
 
@@ -282,4 +289,3 @@
         cms-signature (-> system-signature-cms-service
                           (.signMessageDigest dss-digest signature-parameters signature-value))]
     (.getBytes cms-signature)))
-

--- a/etp-core/etp-backend/src/test/clj/solita/etp/service/signing/pdf_sign_test.clj
+++ b/etp-core/etp-backend/src/test/clj/solita/etp/service/signing/pdf_sign_test.clj
@@ -1,0 +1,29 @@
+(ns solita.etp.service.signing.pdf-sign-test
+  (:require [clojure.test :as t]
+            [solita.etp.service.signing.pdf-sign :as pdf-sign])
+  (:import (com.sun.net.httpserver HttpExchange HttpHandler HttpServer)
+           (eu.europa.esig.dss.service.http.commons CommonsDataLoader)
+           (java.net InetSocketAddress)
+           (java.nio.charset StandardCharsets)))
+
+(defn- response-handler [response-body]
+  (reify HttpHandler
+    (^void handle [_ ^HttpExchange exchange]
+      (.add (.getResponseHeaders exchange) "Content-Encoding" "binary")
+      (.sendResponseHeaders exchange 200 (long (alength response-body)))
+      (with-open [response-stream (.getResponseBody exchange)]
+        (.write response-stream response-body)))))
+
+(t/deftest data-loader-accepts-dvv-binary-content-encoding-test
+  (let [response-body (.getBytes "timestamp-response" StandardCharsets/UTF_8)
+        server (HttpServer/create (InetSocketAddress. "127.0.0.1" 0) 0)]
+    (.createContext server "/" (response-handler response-body))
+    (.start server)
+    (try
+      (let [port (.getPort (.getAddress server))
+            url (str "http://127.0.0.1:" port "/")
+            loader (#'pdf-sign/data-loader-with-disabled-content-compression)]
+        (t/is (= (seq response-body)
+                 (seq (.post loader url (.getBytes "timestamp-query" StandardCharsets/UTF_8))))))
+      (finally
+        (.stop server 0)))))


### PR DESCRIPTION
Some known TSA services seem to set this value, which the decoder end of recent versions of org.apache.httpcomponents.client5/httpclient5 just does not seem to like. But if support for compression is disabled, unknown Content-Encoding is ignored like it used to be in older versions.